### PR TITLE
chore: update website CI to use official GitHub Pages Actions

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,19 +4,26 @@ on:
   push:
     branches: [main]
     paths:
-      - 'website/**'
+      - "website/**"
+      - ".github/workflows/website.yml"
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v6.0.2
 
-      - uses: oven-sh/setup-bun@v2.0.2
+      - uses: oven-sh/setup-bun@v2.1.0
 
       - name: Install dependencies
         run: bun install
@@ -26,9 +33,18 @@ jobs:
         run: bun run build
         working-directory: website
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.7.3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4.0.0
         with:
-          folder: website/build
-          branch: gh-pages
-          clean: true
+          path: website/build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -76,3 +76,4 @@ Client → DBBat (auth + grant check) → Target PostgreSQL
 - [Install DBBat](/docs/installation/docker) using Docker
 - [Configure](/docs/configuration) your environment
 - Learn about [Access Control](/docs/features/access-control)
+


### PR DESCRIPTION
## Summary
- Updates website deployment workflow to use official GitHub Pages Actions (`actions/upload-pages-artifact` and `actions/deploy-pages`) instead of third-party action
- Uses precise version tags (vX.Y.Z) for all actions:
  - `actions/checkout@v6.0.2`
  - `oven-sh/setup-bun@v2.1.0`
  - `actions/upload-pages-artifact@v4.0.0`
  - `actions/deploy-pages@v4.0.5`
- Adds proper permissions for GitHub Pages deployment

## Test plan
- [ ] Verify CI workflow runs successfully
- [ ] Verify website is deployed to https://www.dbbat.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)