### PR TITLE
ci(release): Enable automated releases

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bunx semantic-release --dry-run
+        run: bunx semantic-release


### PR DESCRIPTION
## Summary

- Remove `--dry-run` flag from semantic-release to enable actual version tagging and GitHub release creation

## Test plan

- [ ] Verify Semantic Release workflow runs and creates v1.0.0 release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)