### PR TITLE
docs: fix API endpoints and update documentation

### DIFF
--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -18,11 +18,19 @@ Configuration is loaded in this priority order (highest to lowest):
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
+| `DBB_DSN` | PostgreSQL DSN for DBBat storage | - | Yes |
 | `DBB_LISTEN_PG` | Proxy listen address | `:5434` | No |
 | `DBB_LISTEN_API` | REST API listen address | `:8080` | No |
-| `DBB_DSN` | PostgreSQL DSN for DBBat storage | - | Yes |
-| `DBB_KEY` | Base64-encoded AES-256 encryption key | - | One of KEY/KEYFILE |
-| `DBB_KEYFILE` | Path to file containing encryption key | - | One of KEY/KEYFILE |
+| `DBB_KEY` | Base64-encoded AES-256 encryption key | Auto-generated | No |
+| `DBB_KEYFILE` | Path to file containing encryption key | - | No |
+| `DBB_BASE_URL` | Base URL path for the frontend app | `/app` | No |
+| `DBB_RUN_MODE` | Run mode: empty, `test`, or `demo` | - | No |
+| `DBB_REDIRECTS` | Dev redirect rules for proxying to dev servers | - | No |
+| `DBB_DEMO_TARGET_DB` | Allowed database target in demo mode | `demo:demo@localhost/demo` | No |
+
+:::note
+If no encryption key is provided via `DBB_KEY` or `DBB_KEYFILE`, DBBat automatically generates one and stores it at `~/.dbbat/key`.
+:::
 
 ## Configuration File
 
@@ -44,7 +52,7 @@ dbbat serve --config /etc/dbbat/config.yaml
 
 ## Encryption Key
 
-DBBat requires a 32-byte encryption key for encrypting database credentials.
+DBBat requires a 32-byte encryption key for encrypting database credentials. If not provided, one is automatically generated.
 
 ### Generate a Key
 
@@ -82,6 +90,23 @@ postgres://user:password@host:port/database?sslmode=require
 - `require` - Require SSL but don't verify certificate
 - `verify-ca` - Require SSL and verify CA
 - `verify-full` - Require SSL and verify CA + hostname
+
+## Run Modes
+
+### Test Mode (`DBB_RUN_MODE=test`)
+
+Useful for E2E testing and development:
+- Wipes all data on startup
+- Creates admin user with password `admintest`
+- Creates sample users: `viewer`, `connector`
+- Creates sample database and grants
+
+### Demo Mode (`DBB_RUN_MODE=demo`)
+
+For public demos with restricted database targets:
+- Wipes all data on startup
+- Creates admin user with password `admin`
+- Only allows database configurations matching `DBB_DEMO_TARGET_DB`
 
 ## Default Admin
 

--- a/website/docs/installation/binary.md
+++ b/website/docs/installation/binary.md
@@ -48,8 +48,8 @@ DBBat supports YAML configuration files:
 
 ```yaml
 # dbbat.yaml
-listen_addr: ":5434"
-api_addr: ":8080"
+listen_pg: ":5434"
+listen_api: ":8080"
 dsn: "postgres://user:pass@localhost:5432/dbbat"
 ```
 

--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -61,7 +61,7 @@ docker run -d \
 DBBat exposes a health endpoint:
 
 ```bash
-curl http://localhost:8080/api/health
+curl http://localhost:8080/api/v1/health
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary

- Update README with correct `/api/v1/` prefixed endpoints and link to website
- Use Bearer token authentication instead of Basic Auth in examples
- Update field names: `roles` instead of `is_admin`, `controls` instead of `access_level`
- Add missing environment variables to configuration docs (`DBB_RUN_MODE`, `DBB_BASE_URL`, etc.)
- Document test and demo run modes
- Fix health check endpoint in docker docs (`/api/v1/health`)
- Fix config field names in binary docs (`listen_pg`, `listen_api`)

## Test plan

- [x] Verify all API endpoints use `/api/v1/` prefix
- [x] Verify examples use correct request body fields
- [x] Verify environment variables table is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)