### PR TITLE
perf(auth): implement password verification cache and configurable hash parameters

### DIFF
--- a/internal/cache/auth.go
+++ b/internal/cache/auth.go
@@ -1,0 +1,194 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/fclairamb/dbbat/internal/crypto"
+)
+
+// AuthCache provides caching for password verification results to avoid
+// expensive argon2id re-computation on every request.
+type AuthCache struct {
+	entries map[string]*cacheEntry
+	mu      sync.RWMutex
+	ttl     time.Duration
+	maxSize int
+	enabled bool
+
+	// Stats for monitoring
+	hits   int64
+	misses int64
+}
+
+type cacheEntry struct {
+	valid     bool
+	timestamp time.Time
+}
+
+// AuthCacheConfig holds configuration for the auth cache.
+type AuthCacheConfig struct {
+	Enabled    bool
+	TTLSeconds int
+	MaxSize    int
+}
+
+// NewAuthCache creates a new authentication cache.
+func NewAuthCache(cfg AuthCacheConfig) *AuthCache {
+	cache := &AuthCache{
+		entries: make(map[string]*cacheEntry),
+		ttl:     time.Duration(cfg.TTLSeconds) * time.Second,
+		maxSize: cfg.MaxSize,
+		enabled: cfg.Enabled,
+	}
+
+	if cache.enabled {
+		// Start background cleanup goroutine
+		go cache.cleanupLoop()
+
+		slog.Info("auth cache enabled",
+			"ttl_seconds", cfg.TTLSeconds,
+			"max_size", cfg.MaxSize)
+	}
+
+	return cache
+}
+
+// computeKey generates a cache key from user identifier, password, and hash prefix.
+// Including the hash prefix ensures cache invalidation when password changes.
+func computeKey(userID, password, storedHash string) string {
+	// Use first 32 chars of stored hash as prefix (includes params)
+	hashPrefix := storedHash
+	if len(hashPrefix) > 32 {
+		hashPrefix = hashPrefix[:32]
+	}
+
+	// SHA-256 of combined data for privacy
+	data := userID + ":" + password + ":" + hashPrefix
+	hash := sha256.Sum256([]byte(data))
+
+	return hex.EncodeToString(hash[:])
+}
+
+// VerifyPassword verifies a password, using cache if available.
+// userID should be a unique identifier for the user (e.g., UID).
+func (c *AuthCache) VerifyPassword(userID, password, storedHash string) (bool, error) {
+	if !c.enabled {
+		return crypto.VerifyPassword(storedHash, password)
+	}
+
+	cacheKey := computeKey(userID, password, storedHash)
+
+	// Check cache
+	c.mu.RLock()
+	entry, found := c.entries[cacheKey]
+	if found && time.Since(entry.timestamp) < c.ttl {
+		c.mu.RUnlock()
+		c.mu.Lock()
+		c.hits++
+		c.mu.Unlock()
+
+		slog.Debug("auth cache hit", "user_id", userID)
+
+		return entry.valid, nil
+	}
+	c.mu.RUnlock()
+
+	// Cache miss - verify password
+	c.mu.Lock()
+	c.misses++
+	c.mu.Unlock()
+
+	slog.Debug("auth cache miss", "user_id", userID)
+
+	valid, err := crypto.VerifyPassword(storedHash, password)
+	if err != nil {
+		return false, err
+	}
+
+	// Store result in cache
+	c.set(cacheKey, valid)
+
+	return valid, nil
+}
+
+// set stores a verification result in the cache.
+func (c *AuthCache) set(key string, valid bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict oldest entries if at capacity
+	if len(c.entries) >= c.maxSize {
+		c.evictOldest()
+	}
+
+	c.entries[key] = &cacheEntry{
+		valid:     valid,
+		timestamp: time.Now(),
+	}
+}
+
+// evictOldest removes the oldest entry from the cache.
+// Must be called with lock held.
+func (c *AuthCache) evictOldest() {
+	var oldestKey string
+	var oldestTime time.Time
+
+	for key, entry := range c.entries {
+		if oldestKey == "" || entry.timestamp.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = entry.timestamp
+		}
+	}
+
+	if oldestKey != "" {
+		delete(c.entries, oldestKey)
+	}
+}
+
+// cleanupLoop periodically removes expired entries.
+func (c *AuthCache) cleanupLoop() {
+	ticker := time.NewTicker(c.ttl / 2)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.cleanup()
+	}
+}
+
+// cleanup removes expired entries from the cache.
+func (c *AuthCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range c.entries {
+		if now.Sub(entry.timestamp) >= c.ttl {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// Stats returns cache statistics: hits, misses, and current size.
+func (c *AuthCache) Stats() (int64, int64, int) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.hits, c.misses, len(c.entries)
+}
+
+// Clear removes all entries from the cache.
+func (c *AuthCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries = make(map[string]*cacheEntry)
+}
+
+// Enabled returns whether the cache is enabled.
+func (c *AuthCache) Enabled() bool {
+	return c.enabled
+}

--- a/internal/cache/auth_test.go
+++ b/internal/cache/auth_test.go
@@ -1,0 +1,288 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fclairamb/dbbat/internal/crypto"
+)
+
+func TestAuthCache_VerifyPassword(t *testing.T) {
+	t.Parallel()
+
+	// Create a test password hash
+	password := "testpassword123"
+	hash, err := crypto.HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	cache := NewAuthCache(AuthCacheConfig{
+		Enabled:    true,
+		TTLSeconds: 60,
+		MaxSize:    100,
+	})
+
+	userID := "user-123"
+
+	// First verification should miss cache
+	valid, err := cache.VerifyPassword(userID, password, hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if !valid {
+		t.Error("expected password to be valid")
+	}
+
+	hits, misses, _ := cache.Stats()
+	if hits != 0 || misses != 1 {
+		t.Errorf("expected 0 hits, 1 miss; got %d hits, %d misses", hits, misses)
+	}
+
+	// Second verification should hit cache
+	valid, err = cache.VerifyPassword(userID, password, hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if !valid {
+		t.Error("expected password to be valid")
+	}
+
+	hits, misses, _ = cache.Stats()
+	if hits != 1 || misses != 1 {
+		t.Errorf("expected 1 hit, 1 miss; got %d hits, %d misses", hits, misses)
+	}
+}
+
+func TestAuthCache_WrongPassword(t *testing.T) {
+	t.Parallel()
+
+	password := "correctpassword"
+	hash, err := crypto.HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	cache := NewAuthCache(AuthCacheConfig{
+		Enabled:    true,
+		TTLSeconds: 60,
+		MaxSize:    100,
+	})
+
+	userID := "user-123"
+
+	// Wrong password should not be valid
+	valid, err := cache.VerifyPassword(userID, "wrongpassword", hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if valid {
+		t.Error("expected wrong password to be invalid")
+	}
+
+	// Wrong password should still be cached (as invalid)
+	valid, err = cache.VerifyPassword(userID, "wrongpassword", hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if valid {
+		t.Error("expected wrong password to still be invalid")
+	}
+
+	hits, misses, _ := cache.Stats()
+	if hits != 1 || misses != 1 {
+		t.Errorf("expected 1 hit, 1 miss; got %d hits, %d misses", hits, misses)
+	}
+}
+
+func TestAuthCache_PasswordChange(t *testing.T) {
+	t.Parallel()
+
+	oldPassword := "oldpassword"
+	newPassword := "newpassword"
+
+	oldHash, err := crypto.HashPassword(oldPassword)
+	if err != nil {
+		t.Fatalf("failed to hash old password: %v", err)
+	}
+
+	cache := NewAuthCache(AuthCacheConfig{
+		Enabled:    true,
+		TTLSeconds: 60,
+		MaxSize:    100,
+	})
+
+	userID := "user-123"
+
+	// Verify old password
+	valid, err := cache.VerifyPassword(userID, oldPassword, oldHash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if !valid {
+		t.Error("expected old password to be valid")
+	}
+
+	// Simulate password change
+	newHash, err := crypto.HashPassword(newPassword)
+	if err != nil {
+		t.Fatalf("failed to hash new password: %v", err)
+	}
+
+	// Old password with new hash should be invalid (cache key includes hash prefix)
+	valid, err = cache.VerifyPassword(userID, oldPassword, newHash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if valid {
+		t.Error("expected old password with new hash to be invalid")
+	}
+
+	// New password with new hash should be valid
+	valid, err = cache.VerifyPassword(userID, newPassword, newHash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if !valid {
+		t.Error("expected new password to be valid")
+	}
+}
+
+func TestAuthCache_Disabled(t *testing.T) {
+	t.Parallel()
+
+	password := "testpassword"
+	hash, err := crypto.HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	cache := NewAuthCache(AuthCacheConfig{
+		Enabled:    false,
+		TTLSeconds: 60,
+		MaxSize:    100,
+	})
+
+	userID := "user-123"
+
+	// Should work without caching
+	valid, err := cache.VerifyPassword(userID, password, hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if !valid {
+		t.Error("expected password to be valid")
+	}
+
+	// Stats should show no hits/misses since cache is disabled
+	hits, misses, size := cache.Stats()
+	if hits != 0 || misses != 0 || size != 0 {
+		t.Errorf("expected 0 hits, 0 misses, 0 size; got %d hits, %d misses, %d size", hits, misses, size)
+	}
+}
+
+func TestAuthCache_MaxSize(t *testing.T) {
+	t.Parallel()
+
+	cache := NewAuthCache(AuthCacheConfig{
+		Enabled:    true,
+		TTLSeconds: 60,
+		MaxSize:    3,
+	})
+
+	// Create unique passwords and hashes
+	for i := 0; i < 5; i++ {
+		password := "password"
+		hash, _ := crypto.HashPassword(password)
+		userID := string(rune('a' + i))
+
+		_, err := cache.VerifyPassword(userID, password, hash)
+		if err != nil {
+			t.Fatalf("VerifyPassword failed: %v", err)
+		}
+	}
+
+	// Should not exceed max size
+	_, _, size := cache.Stats()
+	if size > 3 {
+		t.Errorf("cache size %d exceeds max size 3", size)
+	}
+}
+
+func TestAuthCache_TTLExpiry(t *testing.T) {
+	t.Parallel()
+
+	cache := NewAuthCache(AuthCacheConfig{
+		Enabled:    true,
+		TTLSeconds: 1, // 1 second TTL for testing
+		MaxSize:    100,
+	})
+
+	password := "testpassword"
+	hash, err := crypto.HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	userID := "user-123"
+
+	// First call - cache miss
+	_, err = cache.VerifyPassword(userID, password, hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+
+	// Second call - cache hit
+	_, err = cache.VerifyPassword(userID, password, hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+
+	hits, misses, _ := cache.Stats()
+	if hits != 1 || misses != 1 {
+		t.Errorf("expected 1 hit, 1 miss; got %d hits, %d misses", hits, misses)
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(1100 * time.Millisecond)
+
+	// Third call - cache miss (expired)
+	_, err = cache.VerifyPassword(userID, password, hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+
+	hits, misses, _ = cache.Stats()
+	if hits != 1 || misses != 2 {
+		t.Errorf("expected 1 hit, 2 misses after TTL; got %d hits, %d misses", hits, misses)
+	}
+}
+
+func TestComputeKey(t *testing.T) {
+	t.Parallel()
+
+	// Same inputs should produce same key
+	key1 := computeKey("user1", "password", "$argon2id$v=19$m=65536")
+	key2 := computeKey("user1", "password", "$argon2id$v=19$m=65536")
+	if key1 != key2 {
+		t.Error("same inputs should produce same key")
+	}
+
+	// Different user should produce different key
+	key3 := computeKey("user2", "password", "$argon2id$v=19$m=65536")
+	if key1 == key3 {
+		t.Error("different user should produce different key")
+	}
+
+	// Different password should produce different key
+	key4 := computeKey("user1", "different", "$argon2id$v=19$m=65536")
+	if key1 == key4 {
+		t.Error("different password should produce different key")
+	}
+
+	// Different hash prefix should produce different key
+	key5 := computeKey("user1", "password", "$argon2id$v=19$m=32768")
+	if key1 == key5 {
+		t.Error("different hash prefix should produce different key")
+	}
+}

--- a/internal/proxy/auth.go
+++ b/internal/proxy/auth.go
@@ -89,8 +89,13 @@ func (s *Session) authenticate() error {
 		return fmt.Errorf("failed to receive password: %w", err)
 	}
 
-	// Verify password
-	valid, err := crypto.VerifyPassword(user.PasswordHash, passwordMsg.Password)
+	// Verify password (using cache if available)
+	var valid bool
+	if s.authCache != nil {
+		valid, err = s.authCache.VerifyPassword(user.UID.String(), passwordMsg.Password, user.PasswordHash)
+	} else {
+		valid, err = crypto.VerifyPassword(user.PasswordHash, passwordMsg.Password)
+	}
 	if err != nil || !valid {
 		s.sendError("authentication failed")
 

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgproto3"
 
+	"github.com/fclairamb/dbbat/internal/cache"
 	"github.com/fclairamb/dbbat/internal/config"
 	"github.com/fclairamb/dbbat/internal/store"
 )
@@ -69,6 +70,7 @@ type Session struct {
 	logger        *slog.Logger
 	ctx           context.Context //nolint:containedctx // Context is needed for the session lifecycle
 	queryStorage  config.QueryStorageConfig
+	authCache     *cache.AuthCache
 
 	// Session state
 	user                   *store.User
@@ -94,6 +96,7 @@ func NewSession(
 	logger *slog.Logger,
 	ctx context.Context, //nolint:revive // Context parameter order is intentional for this factory
 	queryStorage config.QueryStorageConfig,
+	authCache *cache.AuthCache,
 ) *Session {
 	return &Session{
 		clientConn:    clientConn,
@@ -102,6 +105,7 @@ func NewSession(
 		logger:        logger,
 		ctx:           ctx,
 		queryStorage:  queryStorage,
+		authCache:     authCache,
 		extendedState: &extendedQueryState{
 			preparedStatements: make(map[string]*preparedStatement),
 			portals:            make(map[string]*portalState),

--- a/specs/2026-01-11-password-verification-performance.md
+++ b/specs/2026-01-11-password-verification-performance.md
@@ -60,6 +60,16 @@ Allow administrators to tune Argon2id parameters via configuration.
 
 **Note**: Individual settings override preset values.
 
+#### 1.2a Automatic Test Mode Configuration
+
+When `DBB_RUN_MODE=test`, the hash preset is automatically set to `minimal` unless explicitly overridden. This ensures fast test execution without requiring manual configuration.
+
+| Run Mode | Default Hash Preset | Can Override |
+|----------|-------------------|--------------|
+| (default) | `default` | Yes |
+| `test` | `minimal` | Yes |
+| `demo` | `default` | Yes |
+
 #### 1.2 Configuration Struct
 
 ```go


### PR DESCRIPTION
## Summary

- Add configurable Argon2id parameters via `DBB_HASH_*` environment variables for tuning performance/security tradeoff
- Add hash presets (`default`, `low`, `minimal`) for different environments
- Implement in-memory auth cache for password verification to avoid redundant argon2id computations
- Auto-use minimal hash preset in test mode (`DBB_RUN_MODE=test`) for faster test execution
- Integrate cache into API middleware and proxy authentication

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Linter passes (`make lint`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual testing with API calls to verify cache hits in logs
- [ ] E2E tests pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)