### PR TITLE
fix(config): remove redundant slack_ prefix from SlackAuthConfig koanf tags

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,11 +105,11 @@ type RedirectRule struct {
 
 // SlackAuthConfig holds Slack OAuth configuration.
 type SlackAuthConfig struct {
-	ClientID        string `koanf:"slack_client_id"`
-	ClientSecret    string `koanf:"slack_client_secret"`
-	TeamID          string `koanf:"slack_team_id"`
-	AutoCreateUsers bool   `koanf:"slack_auto_create_users"`
-	DefaultRole     string `koanf:"slack_default_role"`
+	ClientID        string `koanf:"client_id"`
+	ClientSecret    string `koanf:"client_secret"`
+	TeamID          string `koanf:"team_id"`
+	AutoCreateUsers bool   `koanf:"auto_create_users"`
+	DefaultRole     string `koanf:"default_role"`
 }
 
 // Enabled returns true if Slack OAuth is configured with both client ID and secret.


### PR DESCRIPTION
## Summary
- Fix koanf tags on `SlackAuthConfig` fields that included a redundant `slack_` prefix
- Tags like `slack_client_id` under parent `slack_auth` produced paths `slack_auth.slack_client_id`, making env vars `DBB_SLACK_AUTH_CLIENT_ID` silently ignored
- Now env vars `DBB_SLACK_AUTH_CLIENT_ID`, `DBB_SLACK_AUTH_CLIENT_SECRET`, `DBB_SLACK_AUTH_TEAM_ID` correctly map to the config struct

## Test plan
- [x] `go test ./internal/config/...` passes (40 tests)
- [ ] Deploy with `DBB_SLACK_AUTH_CLIENT_ID` env var and verify Slack provider shows in `/api/v1/auth/providers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)