### PR TITLE
fix(auth): redirect OAuth callback to /login route instead of root

### DIFF
--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -172,7 +172,7 @@ func (s *Server) handleOAuthCallback(providerName string) gin.HandlerFunc {
 		if s.config != nil && s.config.BaseURL != "" {
 			baseURL = s.config.BaseURL
 		}
-		c.Redirect(http.StatusFound, baseURL+"/?token="+plainKey)
+		c.Redirect(http.StatusFound, baseURL+"/login?token="+plainKey)
 	}
 }
 


### PR DESCRIPTION
## Summary
- OAuth callback was redirecting to `/app/?token=xxx` (root route)
- The authenticated route guard intercepted this and redirected to `/login`, **dropping the token query param**
- Now redirects to `/app/login?token=xxx`, matching the error redirect pattern
- The login page's `useEffect` picks up the token and completes auth

## Test plan
- [x] `go test ./internal/api/...` passes (55 tests)
- [ ] Click "Sign in with Slack" → should authenticate and redirect to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)