### PR TITLE
test(proxy): add MySQL/MariaDB integration tests with testcontainers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.2 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
@@ -96,6 +97,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/testcontainers/testcontainers-go/modules/mysql v0.42.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.30.2 h1:JiFIMtSSHb2/XBUbWM4i/MpeQm9ZK2xqPNk8vgvu5JQ=
 github.com/go-playground/validator/v10 v10.30.2/go.mod h1:mAf2pIOVXjTEBrwUMGKkCWKKPs9NheYGabeB04txQSc=
+github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
+github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
@@ -214,6 +216,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
+github.com/testcontainers/testcontainers-go/modules/mysql v0.42.0 h1:Yhv1k7vDpyzZePntg5R5Oj4ZMCyWpAfpJeRu1ROsgiU=
+github.com/testcontainers/testcontainers-go/modules/mysql v0.42.0/go.mod h1:Z7SCTuiZlghAdRjkv3Ir0iXJKC2T2avbtxLR0DRe+ng=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0 h1:GCbb1ndrF7OTDiIvxXyItaDab4qkzTFJ48LKFdM7EIo=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0/go.mod h1:IRPBaI8jXdrNfD0e4Zm7Fbcgaz5shKxOQv4axiL09xs=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/proxy/mysql/integration_test.go
+++ b/internal/proxy/mysql/integration_test.go
@@ -1,0 +1,424 @@
+//go:build integration
+
+package mysql
+
+import (
+	"context"
+	"crypto/tls"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	gosqlmysql "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcmysql "github.com/testcontainers/testcontainers-go/modules/mysql"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/fclairamb/dbbat/internal/config"
+	"github.com/fclairamb/dbbat/internal/crypto"
+	"github.com/fclairamb/dbbat/internal/store"
+)
+
+// Default test images. Override with env vars to test alternative versions
+// (e.g. MARIADB_TEST_IMAGE=mariadb:11 for the latest MariaDB).
+const (
+	defaultMySQLImage   = "mysql:8.4"
+	defaultMariaDBImage = "mariadb:10.11"
+)
+
+func mysqlImage() string {
+	if img := os.Getenv("MYSQL_TEST_IMAGE"); img != "" {
+		return img
+	}
+
+	return defaultMySQLImage
+}
+
+func mariadbImage() string {
+	if img := os.Getenv("MARIADB_TEST_IMAGE"); img != "" {
+		return img
+	}
+
+	return defaultMariaDBImage
+}
+
+// runMySQLContainer starts a MySQL or MariaDB container with predictable
+// test credentials and returns its bound host/port.
+//
+// The testcontainers MySQL module hard-codes a "MySQL Community Server"
+// log wait that doesn't match MariaDB, so we override the wait strategy
+// when the image looks like MariaDB.
+func runMySQLContainer(ctx context.Context, t *testing.T, image string) (testcontainers.Container, string, int) {
+	t.Helper()
+
+	opts := []testcontainers.ContainerCustomizer{
+		tcmysql.WithDatabase("testdb"),
+		tcmysql.WithUsername("root"),
+		tcmysql.WithPassword("rootpw"),
+	}
+
+	if strings.Contains(strings.ToLower(image), "mariadb") {
+		// MariaDB logs "ready for connections" before the socket is
+		// actually accepting traffic, so layer a TCP-listener check on top.
+		opts = append(opts, testcontainers.WithWaitStrategy(
+			wait.ForAll(
+				wait.ForLog("ready for connections"),
+				wait.ForListeningPort("3306/tcp"),
+			).WithStartupTimeoutDefault(120*time.Second),
+		))
+	}
+
+	c, err := tcmysql.Run(ctx, image, opts...)
+	require.NoError(t, err, "start mysql container (%s)", image)
+
+	host, err := c.Host(ctx)
+	require.NoError(t, err)
+
+	port, err := c.MappedPort(ctx, "3306")
+	require.NoError(t, err)
+
+	t.Logf("MySQL container ready: image=%s host=%s port=%s", image, host, port.Port())
+
+	return c, host, int(port.Num())
+}
+
+// fixture wires up: PG storage container, dbbat store, a user/database/grant,
+// and a started MySQL proxy. Returns the proxy's listen address and a
+// teardown that stops everything.
+type fixture struct {
+	t            *testing.T
+	store        *store.Store
+	proxy        *Server
+	proxyAddr    string
+	upstreamHost string
+	upstreamPort int
+	username     string
+	password     string
+	dbName       string
+}
+
+const fixtureUser = "dbbattest"
+const fixturePass = "dbbattest"
+
+func setupFixture(ctx context.Context, t *testing.T, mysqlImage, dbProtocol string) *fixture {
+	t.Helper()
+
+	upstreamContainer, upstreamHost, upstreamPort := runMySQLContainer(ctx, t, mysqlImage)
+	t.Cleanup(func() { _ = upstreamContainer.Terminate(context.Background()) })
+
+	pgContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "postgres:15-alpine",
+			ExposedPorts: []string{"5432/tcp"},
+			Env: map[string]string{
+				"POSTGRES_DB":       "dbbat_test",
+				"POSTGRES_USER":     "test",
+				"POSTGRES_PASSWORD": "test",
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
+
+	pgHost, _ := pgContainer.Host(ctx)
+	pgPort, _ := pgContainer.MappedPort(ctx, "5432")
+	pgDSN := fmt.Sprintf("postgres://test:test@%s:%s/dbbat_test?sslmode=disable", pgHost, pgPort.Port())
+
+	dataStore, err := store.New(ctx, pgDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { dataStore.Close() })
+
+	require.NoError(t, dataStore.Migrate(ctx))
+
+	hash, err := crypto.HashPassword(fixturePass)
+	require.NoError(t, err)
+
+	user, err := dataStore.CreateUser(ctx, fixtureUser, hash, []string{"connector"})
+	require.NoError(t, err)
+
+	encryptionKey := make([]byte, 32)
+	for i := range encryptionKey {
+		encryptionKey[i] = byte(i + 1)
+	}
+
+	db, err := dataStore.CreateDatabase(ctx, &store.Database{
+		Name:         "testdb",
+		Host:         upstreamHost,
+		Port:         upstreamPort,
+		DatabaseName: "testdb",
+		Username:     "root",
+		Password:     "rootpw",
+		Protocol:     dbProtocol,
+		SSLMode:      "disable",
+	}, encryptionKey)
+	require.NoError(t, err)
+
+	_, err = dataStore.CreateGrant(ctx, &store.Grant{
+		UserID:     user.UID,
+		DatabaseID: db.UID,
+		GrantedBy:  user.UID,
+		Controls:   []string{},
+		StartsAt:   time.Now().Add(-time.Hour),
+		ExpiresAt:  time.Now().Add(24 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	queryStorage := config.QueryStorageConfig{
+		StoreResults:   true,
+		MaxResultRows:  1000,
+		MaxResultBytes: 1 * 1024 * 1024,
+	}
+
+	proxy, err := NewServer(dataStore, encryptionKey, queryStorage, config.DumpConfig{},
+		nil, config.MySQLConfig{}, slog.Default())
+	require.NoError(t, err)
+
+	go func() { _ = proxy.Start("127.0.0.1:0") }()
+
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Shutdown(shutdownCtx)
+	})
+
+	require.Eventually(t, func() bool { return proxy.Addr() != nil },
+		2*time.Second, 50*time.Millisecond, "proxy never started listening")
+
+	return &fixture{
+		t:            t,
+		store:        dataStore,
+		proxy:        proxy,
+		proxyAddr:    proxy.Addr().String(),
+		upstreamHost: upstreamHost,
+		upstreamPort: upstreamPort,
+		username:     fixtureUser,
+		password:     fixturePass,
+		dbName:       "testdb",
+	}
+}
+
+// dialTLS returns a *sql.DB connected through the proxy with TLS skip-verify
+// enabled (the proxy auto-generates a self-signed cert).
+func (f *fixture) dialTLS() *sql.DB {
+	f.t.Helper()
+
+	return f.dialWithTLSConfig("dbbat-skip-verify")
+}
+
+// dialPlain connects without TLS.
+func (f *fixture) dialPlain() *sql.DB {
+	f.t.Helper()
+
+	cfg := f.driverConfig()
+	cfg.TLSConfig = "false"
+	cfg.AllowCleartextPasswords = true
+	cfg.AllowNativePasswords = false
+
+	return f.openWithConfig(cfg)
+}
+
+func (f *fixture) dialWithTLSConfig(name string) *sql.DB {
+	cfg := f.driverConfig()
+	cfg.TLSConfig = name
+	cfg.AllowCleartextPasswords = true
+
+	return f.openWithConfig(cfg)
+}
+
+func (f *fixture) driverConfig() *gosqlmysql.Config {
+	host, port, _ := net.SplitHostPort(f.proxyAddr)
+
+	cfg := gosqlmysql.NewConfig()
+	cfg.User = f.username
+	cfg.Passwd = f.password
+	cfg.Net = "tcp"
+	cfg.Addr = host + ":" + port
+	cfg.DBName = f.dbName
+	cfg.AllowNativePasswords = false // force caching_sha2/clear path
+
+	return cfg
+}
+
+func (f *fixture) openWithConfig(cfg *gosqlmysql.Config) *sql.DB {
+	connector, err := gosqlmysql.NewConnector(cfg)
+	require.NoError(f.t, err)
+
+	return sql.OpenDB(connector)
+}
+
+// init registers a TLS skip-verify config under the name "dbbat-skip-verify"
+// for use with go-sql-driver/mysql's tls=<name> config parameter.
+func init() {
+	_ = gosqlmysql.RegisterTLSConfig("dbbat-skip-verify", &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // testing self-signed proxy cert
+		MinVersion:         tls.VersionTLS12,
+	})
+}
+
+// ---------- Tests ----------
+
+// TestIntegration_MySQLContainer is a sanity check: the MySQL testcontainer
+// works and we can reach it directly without the proxy. If this fails, all
+// other tests will too — fail fast.
+func TestIntegration_MySQLContainer(t *testing.T) {
+	ctx := context.Background()
+
+	c, host, port := runMySQLContainer(ctx, t, mysqlImage())
+	defer func() { _ = c.Terminate(ctx) }()
+
+	dsn := fmt.Sprintf("root:rootpw@tcp(%s:%d)/testdb", host, port)
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.PingContext(ctx))
+
+	var version string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version))
+	t.Logf("MySQL version: %s", version)
+}
+
+// TestIntegration_ProxyHandshake_TLS exercises the caching_sha2_password
+// path through TLS termination. The proxy auto-generates a self-signed cert,
+// the client uses TLS with skip-verify.
+func TestIntegration_ProxyHandshake_TLS(t *testing.T) {
+	ctx := context.Background()
+
+	f := setupFixture(ctx, t, mysqlImage(), store.ProtocolMySQL)
+	db := f.dialTLS()
+	defer db.Close()
+
+	require.NoError(t, db.PingContext(ctx))
+
+	var one int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+	assert.Equal(t, 1, one)
+}
+
+// TestIntegration_QueryAndCapture verifies result rows are captured into
+// the store after a SELECT through the proxy.
+func TestIntegration_QueryAndCapture(t *testing.T) {
+	ctx := context.Background()
+
+	f := setupFixture(ctx, t, mysqlImage(), store.ProtocolMySQL)
+	db := f.dialTLS()
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, "SELECT 1, 'hello', NULL")
+	require.NoError(t, err)
+
+	var (
+		i int
+		s string
+		n sql.NullString
+	)
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&i, &s, &n))
+	require.NoError(t, rows.Close())
+
+	assert.Equal(t, 1, i)
+	assert.Equal(t, "hello", s)
+	assert.False(t, n.Valid)
+
+	// Allow async write to land
+	time.Sleep(200 * time.Millisecond)
+
+	queries, err := f.store.ListQueries(ctx, store.QueryFilter{Limit: 10})
+	require.NoError(t, err)
+
+	var found bool
+
+	for _, q := range queries {
+		if strings.Contains(q.SQLText, "SELECT 1") {
+			found = true
+
+			break
+		}
+	}
+
+	assert.True(t, found, "expected SELECT 1 to be logged in queries table")
+}
+
+// TestIntegration_ReadOnlyGrant_BlocksWrite verifies that a grant with
+// read_only control rejects an INSERT statement at the proxy layer.
+func TestIntegration_ReadOnlyGrant_BlocksWrite(t *testing.T) {
+	ctx := context.Background()
+
+	f := setupFixture(ctx, t, mysqlImage(), store.ProtocolMySQL)
+
+	// Replace the existing grant with a read-only one.
+	grants, err := f.store.ListGrants(ctx, store.GrantFilter{ActiveOnly: true})
+	require.NoError(t, err)
+	require.NotEmpty(t, grants)
+
+	user, err := f.store.GetUserByUsername(ctx, fixtureUser)
+	require.NoError(t, err)
+
+	for _, g := range grants {
+		require.NoError(t, f.store.RevokeGrant(ctx, g.UID, user.UID))
+	}
+
+	databases, err := f.store.ListDatabases(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, databases)
+
+	_, err = f.store.CreateGrant(ctx, &store.Grant{
+		UserID:     user.UID,
+		DatabaseID: databases[0].UID,
+		GrantedBy:  user.UID,
+		Controls:   []string{"read_only"},
+		StartsAt:   time.Now().Add(-time.Hour),
+		ExpiresAt:  time.Now().Add(24 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	db := f.dialTLS()
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, "CREATE TABLE if not exists t (x int)")
+	require.Error(t, err, "DDL must be refused under read-only grant")
+}
+
+// TestIntegration_LoadDataInfile_Blocked verifies LOAD DATA INFILE is
+// rejected — both the regex pattern and (eventually) the protocol-level
+// LOCAL_INFILE response.
+func TestIntegration_LoadDataInfile_Blocked(t *testing.T) {
+	ctx := context.Background()
+
+	f := setupFixture(ctx, t, mysqlImage(), store.ProtocolMySQL)
+	db := f.dialTLS()
+	defer db.Close()
+
+	_, err := db.ExecContext(ctx, "LOAD DATA INFILE '/etc/passwd' INTO TABLE t")
+	require.Error(t, err, "LOAD DATA INFILE must be refused")
+}
+
+// TestIntegration_MariaDB exercises the same proxy path with a MariaDB
+// upstream and the protocol="mariadb" routing.
+func TestIntegration_MariaDB(t *testing.T) {
+	ctx := context.Background()
+
+	f := setupFixture(ctx, t, mariadbImage(), store.ProtocolMariaDB)
+	db := f.dialTLS()
+	defer db.Close()
+
+	require.NoError(t, db.PingContext(ctx))
+
+	var version string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version))
+
+	t.Logf("MariaDB version through proxy: %s", version)
+	assert.Contains(t, strings.ToLower(version), "mariadb",
+		"expected mariadb in version banner")
+}

--- a/internal/proxy/mysql/server.go
+++ b/internal/proxy/mysql/server.go
@@ -116,6 +116,17 @@ func (s *Server) Start(addr string) error {
 	}
 }
 
+// Addr returns the listener's bound address, or nil if the server has not
+// started accepting connections yet. Useful in tests that pass ":0" for the
+// listen address and need to discover the OS-assigned port.
+func (s *Server) Addr() net.Addr {
+	if s.listener == nil {
+		return nil
+	}
+
+	return s.listener.Addr()
+}
+
 // Shutdown gracefully shuts down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
 	close(s.shutdown)


### PR DESCRIPTION
## Summary

Real end-to-end tests for the MySQL proxy, behind the existing \`integration\` build tag. Spawns a MySQL 8.4 (or MariaDB 10.11) container plus a Postgres-storage container, wires up a user/database/grant in dbbat's store, starts the proxy on ephemeral port, and connects through with go-sql-driver/mysql.

Coverage:
- TLS handshake + caching_sha2_password full-auth (auto-generated self-signed cert)
- COM_QUERY round-trip with row capture into the \`queries\` log
- Read-only grant blocks DDL
- LOAD DATA INFILE refused
- MariaDB upstream routed via \`protocol=\"mariadb\"\`

Adds an \`Addr()\` accessor on the MySQL Server so tests can bind \`:0\` and discover the OS-assigned port.

Pulls in two deps that were missing: \`testcontainers-go/modules/mysql\` and \`go-sql-driver/mysql\`.

Run with:
\`\`\`
go test -tags integration ./internal/proxy/mysql/...
\`\`\`

## Test plan
- [x] \`go test -tags integration ./internal/proxy/mysql/...\` (33 passing locally against Docker)
- [x] \`go test ./...\` still 896 passing
- [x] \`golangci-lint run --build-tags integration ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)