### PR TITLE
feat(proxy): MySQL hardening — LOCAL INFILE defense and binary row capture test

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -184,9 +184,12 @@ Same model as PG/Oracle — every command is logged in the `queries` table with 
 
 ## Result Row Capture
 
-**Phase 3 (v1):** Text-protocol result rows from `COM_QUERY` are captured up to `query_storage.max_result_rows` / `max_result_bytes` (same limits as PG). Rows are stored in the `query_rows` table as JSONB.
+Result rows from both protocol paths are captured up to `query_storage.max_result_rows` / `max_result_bytes` (same limits as PG):
 
-**Future:** Binary-protocol rows from `COM_STMT_EXECUTE` require parsing each column according to its type code (24+ MySQL types). Deferred to a follow-up spec.
+- **Text protocol** (`COM_QUERY`): rows arrive as `[]byte` per column and are encoded as UTF-8 strings or base64'd `$bytes`/`$type` markers for binary blobs.
+- **Binary protocol** (`COM_STMT_EXECUTE`): go-mysql's high-level `Result.Resultset` decodes each column according to its type code before we see it, so the same `captureRows` path serializes both. Numeric columns become JSON numbers, JSON columns are parsed if valid, blobs are base64-marked, everything else is a string.
+
+Rows are stored in the `query_rows` table as JSONB.
 
 ## Implementation Notes
 
@@ -198,13 +201,20 @@ A self-test (`cachingsha2_test.go:TestReadConnSalt_FieldExists`) fails loudly if
 
 If the test fails after a `go.mod` upgrade: either pin go-mysql back, or extend the patch to expose `Salt()` upstream and remove the reflection.
 
+## LOCAL INFILE Defense-in-Depth
+
+`LOAD DATA LOCAL INFILE` is the MySQL feature that lets a server *ask* a connected client to upload an arbitrary local file. A compromised upstream server can issue this request mid-query against any client — including a proxy. Two layers prevent that:
+
+1. **SQL regex** (shared with PG/Oracle) refuses the keyword in inbound client queries.
+2. **Capability opt-out**: when the proxy connects upstream it explicitly clears `CLIENT_LOCAL_FILES` from the negotiated capabilities (`upstream.go: c.UnsetCapability(...)`). The upstream then never advertises the feature on this connection, so even a compromised server cannot request a LOCAL INFILE upload through the proxy.
+
 ## Known Limitations
 
-- **Binary-protocol result row capture** (prepared statement EXECUTE results) not yet implemented — SQL text and parameters are logged, but rows aren't captured. Text protocol works fully.
 - **Stored procedure multi-result-sets:** only the first result set is captured.
 - **`COM_FIELD_LIST`** (deprecated since 5.7) is forwarded but not specially logged.
 - **MariaDB `STMT_BULK_EXECUTE`** is refused (clients need to disable batch rewriting).
 - **`mysql_native_password`** is intentionally not supported — all modern clients negotiate `caching_sha2_password` instead.
+- **Session packet dumps** (`DBB_DUMP_DIR`) are not yet wired up for the MySQL proxy. PG and Oracle dump session traffic; MySQL does not.
 
 ## Testing
 

--- a/internal/proxy/mysql/integration_test.go
+++ b/internal/proxy/mysql/integration_test.go
@@ -350,6 +350,62 @@ func TestIntegration_QueryAndCapture(t *testing.T) {
 	assert.True(t, found, "expected SELECT 1 to be logged in queries table")
 }
 
+// TestIntegration_PreparedStatement_BinaryRowCapture exercises the binary
+// protocol path (COM_STMT_PREPARE + COM_STMT_EXECUTE) through the proxy and
+// verifies the captured rows match what the client received.
+//
+// go-sql-driver/mysql uses binary protocol for any query with bind args.
+// Without InterpolateParams, this test forces COM_STMT_EXECUTE rather than
+// inline-substituted COM_QUERY.
+func TestIntegration_PreparedStatement_BinaryRowCapture(t *testing.T) {
+	ctx := context.Background()
+
+	f := setupFixture(ctx, t, mysqlImage(), store.ProtocolMySQL)
+	db := f.dialTLS()
+	defer db.Close()
+
+	stmt, err := db.PrepareContext(ctx, "SELECT ? + ?, ?")
+	require.NoError(t, err)
+	defer stmt.Close()
+
+	var sum int
+
+	var label string
+
+	require.NoError(t, stmt.QueryRowContext(ctx, 7, 35, "binary").Scan(&sum, &label))
+	assert.Equal(t, 42, sum)
+	assert.Equal(t, "binary", label)
+
+	// Allow async write to land.
+	time.Sleep(300 * time.Millisecond)
+
+	queries, err := f.store.ListQueries(ctx, store.QueryFilter{Limit: 50})
+	require.NoError(t, err)
+
+	var executeQuery *store.Query
+
+	for i := range queries {
+		if strings.Contains(queries[i].SQLText, "SELECT ? + ?, ?") &&
+			!strings.HasPrefix(queries[i].SQLText, "PREPARE:") {
+			executeQuery = &queries[i]
+
+			break
+		}
+	}
+
+	require.NotNil(t, executeQuery, "expected COM_STMT_EXECUTE entry in queries log")
+
+	result, err := f.store.GetQueryRows(ctx, executeQuery.UID, "", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Rows, "binary-protocol rows must be captured")
+
+	t.Logf("captured row: %s", string(result.Rows[0].RowData))
+	assert.Contains(t, string(result.Rows[0].RowData), "42",
+		"captured row should include the computed sum")
+	assert.Contains(t, string(result.Rows[0].RowData), "binary",
+		"captured row should include the string literal")
+}
+
 // TestIntegration_ReadOnlyGrant_BlocksWrite verifies that a grant with
 // read_only control rejects an INSERT statement at the proxy layer.
 func TestIntegration_ReadOnlyGrant_BlocksWrite(t *testing.T) {

--- a/internal/proxy/mysql/upstream.go
+++ b/internal/proxy/mysql/upstream.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	gomysqlclient "github.com/go-mysql-org/go-mysql/client"
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 
 	"github.com/fclairamb/dbbat/internal/version"
 )
@@ -50,8 +51,10 @@ func (s *Session) connectUpstream() error {
 }
 
 // applyUpstreamOptions configures the upstream client connection: TLS mode
-// from the database's ssl_mode column, and a connection attribute identifying
-// dbbat as the application.
+// from the database's ssl_mode column, a connection attribute identifying
+// dbbat as the application, and explicit refusal of CLIENT_LOCAL_FILES so a
+// compromised upstream cannot ask the proxy to upload arbitrary files via
+// `LOAD DATA LOCAL INFILE` mid-query.
 func (s *Session) applyUpstreamOptions(c *gomysqlclient.Conn) error {
 	switch s.database.SSLMode {
 	case "require":
@@ -62,6 +65,14 @@ func (s *Session) applyUpstreamOptions(c *gomysqlclient.Conn) error {
 		// plaintext upstream — also the path for "prefer"/"allow" since the
 		// client doesn't currently negotiate opportunistic TLS for MySQL
 	}
+
+	// Defense-in-depth: refuse the LOCAL INFILE capability on the upstream
+	// connection. The shared SQL validator already blocks the keyword in
+	// inbound client SQL, but a malicious upstream could still issue a
+	// LOCAL_INFILE_REQUEST (0xFB) packet as part of any query response — and
+	// the go-mysql client would happily read the file from the proxy host's
+	// filesystem unless we opt out at handshake time.
+	c.UnsetCapability(gomysql.CLIENT_LOCAL_FILES)
 
 	c.SetAttributes(map[string]string{
 		"program_name": "dbbat-" + version.Version,


### PR DESCRIPTION
## Summary

Two MySQL proxy hardening items:

- **Defense-in-depth LOCAL INFILE**: clears \`CLIENT_LOCAL_FILES\` on the upstream connection so a compromised MySQL server cannot ask the proxy to upload arbitrary local files mid-query. The shared SQL regex already blocked the inbound keyword; this closes the equivalent attack from the server side.
- **Binary-protocol row capture, verified**: new integration test uses a prepared statement (forces \`COM_STMT_EXECUTE\` rather than text-protocol \`COM_QUERY\`) and asserts the captured row content. The existing \`captureRows\` path already sees binary columns decoded by go-mysql's \`Result.Resultset\` — this just proves it.

Doc updates:
- describe both protocol paths in the result-row section
- document the LOCAL INFILE two-layer defense
- drop the now-incorrect \"binary protocol not yet implemented\" follow-up note

## Test plan
- [x] \`go test ./...\` (896 passing)
- [x] \`go test -tags integration ./internal/proxy/mysql/...\` (34 passing locally)
- [x] \`golangci-lint run --build-tags integration ./internal/proxy/mysql/...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)