### PR TITLE
feat(proxy): wire up MySQL session packet dumps

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -214,7 +214,10 @@ If the test fails after a `go.mod` upgrade: either pin go-mysql back, or extend 
 - **`COM_FIELD_LIST`** (deprecated since 5.7) is forwarded but not specially logged.
 - **MariaDB `STMT_BULK_EXECUTE`** is refused (clients need to disable batch rewriting).
 - **`mysql_native_password`** is intentionally not supported — all modern clients negotiate `caching_sha2_password` instead.
-- **Session packet dumps** (`DBB_DUMP_DIR`) are not yet wired up for the MySQL proxy. PG and Oracle dump session traffic; MySQL does not.
+
+## Session Packet Dumps
+
+When `DBB_DUMP_DIR` is set, the MySQL proxy writes a per-session `.dbbat-dump` file containing the post-auth command-phase byte stream (matching the PG and Oracle proxies). The filename is the connection UID. Wiring is in `session.go: startDumpIfConfigured` — it swaps the underlying `net.Conn` on the live `packet.Conn` for a `dump.TapConn` after `recordConnection` runs, so the auth handshake itself is never captured. For TLS-upgraded connections the tap sees TLS records, which still preserves timing and packet boundaries.
 
 ## Testing
 

--- a/internal/dump/dump.go
+++ b/internal/dump/dump.go
@@ -27,6 +27,7 @@ const (
 const (
 	ProtocolOracle     = "oracle"
 	ProtocolPostgreSQL = "postgresql"
+	ProtocolMySQL      = "mysql"
 )
 
 // Packet frame size: 8 (relativeNs) + 1 (direction) + 4 (length).

--- a/internal/proxy/mysql/integration_test.go
+++ b/internal/proxy/mysql/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -110,6 +111,12 @@ const fixturePass = "dbbattest"
 func setupFixture(ctx context.Context, t *testing.T, mysqlImage, dbProtocol string) *fixture {
 	t.Helper()
 
+	return setupFixtureWithDumpDir(ctx, t, mysqlImage, dbProtocol, "")
+}
+
+func setupFixtureWithDumpDir(ctx context.Context, t *testing.T, mysqlImage, dbProtocol, dumpDir string) *fixture {
+	t.Helper()
+
 	upstreamContainer, upstreamHost, upstreamPort := runMySQLContainer(ctx, t, mysqlImage)
 	t.Cleanup(func() { _ = upstreamContainer.Terminate(context.Background()) })
 
@@ -180,7 +187,16 @@ func setupFixture(ctx context.Context, t *testing.T, mysqlImage, dbProtocol stri
 		MaxResultBytes: 1 * 1024 * 1024,
 	}
 
-	proxy, err := NewServer(dataStore, encryptionKey, queryStorage, config.DumpConfig{},
+	dumpCfg := config.DumpConfig{}
+	if dumpDir != "" {
+		dumpCfg = config.DumpConfig{
+			Dir:       dumpDir,
+			MaxSize:   config.DefaultDumpMaxSize,
+			Retention: config.DefaultDumpRetention,
+		}
+	}
+
+	proxy, err := NewServer(dataStore, encryptionKey, queryStorage, dumpCfg,
 		nil, config.MySQLConfig{}, slog.Default())
 	require.NoError(t, err)
 
@@ -458,6 +474,50 @@ func TestIntegration_LoadDataInfile_Blocked(t *testing.T) {
 
 	_, err := db.ExecContext(ctx, "LOAD DATA INFILE '/etc/passwd' INTO TABLE t")
 	require.Error(t, err, "LOAD DATA INFILE must be refused")
+}
+
+// TestIntegration_SessionDump verifies that when DBB_DUMP_DIR is configured
+// the MySQL session writes a per-connection dump file containing post-auth
+// command-phase traffic.
+func TestIntegration_SessionDump(t *testing.T) {
+	ctx := context.Background()
+
+	dumpDir := t.TempDir()
+
+	f := setupFixtureWithDumpDir(ctx, t, mysqlImage(), store.ProtocolMySQL, dumpDir)
+	db := f.dialTLS()
+
+	require.NoError(t, db.PingContext(ctx))
+
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT 99").Scan(&n))
+	assert.Equal(t, 99, n)
+
+	require.NoError(t, db.Close())
+
+	// Allow the proxy to flush + close the dump.
+	time.Sleep(300 * time.Millisecond)
+
+	entries, err := os.ReadDir(dumpDir)
+	require.NoError(t, err)
+
+	var dumpFile string
+
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".dbbat-dump") {
+			dumpFile = filepath.Join(dumpDir, e.Name())
+
+			break
+		}
+	}
+
+	require.NotEmpty(t, dumpFile, "expected a .dbbatdump file in %s", dumpDir)
+
+	stat, err := os.Stat(dumpFile)
+	require.NoError(t, err)
+	assert.Greater(t, stat.Size(), int64(0), "dump file should not be empty after a query round-trip")
+
+	t.Logf("dump file: %s (%d bytes)", dumpFile, stat.Size())
 }
 
 // TestIntegration_MariaDB exercises the same proxy path with a MariaDB

--- a/internal/proxy/mysql/session.go
+++ b/internal/proxy/mysql/session.go
@@ -7,10 +7,13 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"path/filepath"
+	"time"
 
 	gomysqlclient "github.com/go-mysql-org/go-mysql/client"
 	gomysqlserver "github.com/go-mysql-org/go-mysql/server"
 
+	"github.com/fclairamb/dbbat/internal/dump"
 	"github.com/fclairamb/dbbat/internal/store"
 )
 
@@ -35,6 +38,9 @@ type Session struct {
 
 	// DBBat connection record (insert on connect, close on disconnect).
 	connection *store.Connection
+
+	// Optional packet dump for the post-auth phase (matches PG behavior).
+	dumpWriter *dump.Writer
 
 	logger *slog.Logger
 	ctx    context.Context //nolint:containedctx // Session-scoped context
@@ -78,6 +84,9 @@ func (s *Session) Run() error {
 	}
 
 	defer s.recordDisconnect()
+
+	s.startDumpIfConfigured()
+	defer s.closeDump()
 
 	s.logger.InfoContext(s.ctx, "MySQL session ready",
 		slog.String("user", s.user.Username),
@@ -132,4 +141,66 @@ func (s *Session) recordDisconnect() {
 			slog.Any("connection_id", s.connection.UID),
 			slog.Any("error", err))
 	}
+}
+
+// startDumpIfConfigured opens a packet-dump file for this session and tees the
+// underlying client connection through it. We only capture the post-auth phase
+// (matching the PG proxy) — the dump is wired up after recordConnection has
+// run, so the auth handshake is already done by the time bytes start flowing
+// through the tap.
+//
+// For TLS-upgraded connections the library has already replaced
+// c.Conn.Conn with a *tls.Conn before this point; the tap will see TLS
+// records (encrypted application data), which is fine — the dump captures
+// timing and packet boundaries even when payload is opaque.
+func (s *Session) startDumpIfConfigured() {
+	if s.server.dumpConfig.Dir == "" || s.connection == nil || s.serverConn == nil {
+		return
+	}
+
+	dumpPath := filepath.Join(s.server.dumpConfig.Dir, s.connection.UID.String()+dump.FileExt)
+
+	dw, err := dump.NewWriter(dumpPath, dump.Header{
+		SessionID: s.connection.UID.String(),
+		Protocol:  dump.ProtocolMySQL,
+		StartTime: time.Now(),
+		Connection: map[string]any{
+			"database":      s.database.DatabaseName,
+			"user":          s.user.Username,
+			"upstream_addr": net.JoinHostPort(s.database.Host, fmt.Sprintf("%d", s.database.Port)),
+			"protocol":      s.database.Protocol,
+		},
+	}, s.server.dumpConfig.MaxSize)
+	if err != nil {
+		s.logger.WarnContext(s.ctx, "MySQL dump writer create failed", slog.Any("error", err))
+
+		return
+	}
+
+	s.dumpWriter = dw
+
+	// Replace the underlying net.Conn on the live packet.Conn with a tap.
+	// Subsequent reads/writes from go-mysql go through the tap; the buffered
+	// reader inside packet.Conn ultimately calls the embedded conn's Read,
+	// which now hits our tap.
+	if s.serverConn.Conn != nil {
+		s.serverConn.Conn.Conn = dump.NewTapConn(
+			s.serverConn.Conn.Conn,
+			dw,
+			dump.DirClientToServer,
+			dump.DirServerToClient,
+		)
+	}
+}
+
+func (s *Session) closeDump() {
+	if s.dumpWriter == nil {
+		return
+	}
+
+	if err := s.dumpWriter.Close(); err != nil {
+		s.logger.WarnContext(s.ctx, "MySQL dump writer close failed", slog.Any("error", err))
+	}
+
+	s.dumpWriter = nil
 }


### PR DESCRIPTION
## Summary

When \`DBB_DUMP_DIR\` is set, the MySQL proxy now writes a per-session \`.dbbat-dump\` file capturing post-auth command-phase traffic — same behavior as PG and Oracle. Closes the last gap in the MySQL v2 known-limitations list.

Implementation: after \`recordConnection\` runs we open a \`dump.Writer\` and replace the \`net.Conn\` embedded in the live \`packet.Conn\` with a \`dump.TapConn\`. Subsequent reads/writes from go-mysql go through the tap. Auth bytes are never captured (matches PG, avoids leaking plaintext passwords from non-TLS sessions).

Also adds \`dump.ProtocolMySQL\` so dump files identify their protocol.

## Test plan
- [x] \`go test ./...\` (896 passing)
- [x] \`go test -tags integration ./internal/proxy/mysql/...\` (35 passing — adds TestIntegration_SessionDump)
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)