### PR TITLE
docs: cover multi-engine support (PostgreSQL, Oracle, MySQL/MariaDB)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # DBBat - Database Observability Proxy
 
-A transparent database proxy for query observability, access control, and safety. Supports PostgreSQL and Oracle. Every query logged. Every connection tracked.
+A transparent database proxy for query observability, access control, and safety. Supports **PostgreSQL**, **Oracle**, and **MySQL/MariaDB**. Every query logged. Every connection tracked.
 
 ## Semantic Versioning
 
@@ -27,7 +27,7 @@ PR titles MUST follow the conventional commit format:
 | `ci` | CI configuration | None |
 | `chore` | Other changes (deps, tooling) | None |
 
-**Scopes** (optional): `api`, `auth`, `config`, `crypto`, `db`, `deps`, `docs`, `grants`, `migrations`, `proxy`, `store`, `ui`, `release`
+**Scopes** (optional): `api`, `auth`, `config`, `crypto`, `db`, `deps`, `docs`, `dump`, `grants`, `migrations`, `mysql`, `oracle`, `proxy`, `store`, `ui`, `release`
 
 **Breaking Changes:** Add `!` after type/scope or include `BREAKING CHANGE:` in body for major version bumps.
 
@@ -42,30 +42,40 @@ PR titles MUST follow the conventional commit format:
 - **Language**: Go
 - **Storage**: PostgreSQL
 - **ORM**: `uptrace/bun` with SQL migrations
-- **Proxy**: PostgreSQL wire protocol via `jackc/pgx/v5`, Oracle TNS/TTC protocol
-- **Oracle docs**: See `docs/oracle.md` for TNS/TTC protocol details
+- **Proxies**:
+  - PostgreSQL wire protocol via `jackc/pgx/v5`
+  - Oracle TNS/TTC (hand-rolled) — see `docs/oracle.md`
+  - MySQL/MariaDB via `go-mysql-org/go-mysql` (server + client) — see `docs/mysql.md`
 - **API**: `gin-gonic/gin` with OpenAPI 3.0 docs
 - **CLI**: `urfave/cli/v3`
 - **Config**: `knadh/koanf`
 - **Logging**: `log/slog`
 - **Frontend**: React 19 + TypeScript + Vite (see `front/CLAUDE.md`)
+- **Dump format**: Protocol-agnostic binary capture (`docs/dump-format.md`)
 
 ## Project Structure
 
 ```
 dbbat/
-├── cmd/dbbat/main.go        # Entry point with CLI commands
+├── main.go                  # Entry point with CLI commands (serve, db, dump)
 ├── internal/
-│   ├── config/              # Environment config loading
+│   ├── config/              # koanf-based config loading (env, file, CLI)
 │   ├── crypto/              # Password hashing (Argon2id) + AES-256-GCM encryption
 │   ├── migrations/sql/      # SQL migration files (up/down)
 │   ├── store/               # Database models and CRUD operations
+│   ├── cache/               # Auth cache shared by API + proxies
+│   ├── dump/                # Session packet dump format (read/write/anonymise)
 │   ├── api/                 # REST API handlers and middleware
 │   │   └── openapi.yml      # OpenAPI 3.0 specification
-│   ├── proxy/               # PostgreSQL proxy (auth, upstream, query interception)
-│   │   └── oracle/          # Oracle TNS/TTC proxy (see docs/oracle.md)
+│   ├── proxy/
+│   │   ├── shared/          # Auth, query interception shared across protocols
+│   │   ├── postgresql/      # PostgreSQL wire protocol proxy
+│   │   ├── oracle/          # Oracle TNS/TTC proxy (see docs/oracle.md)
+│   │   └── mysql/           # MySQL/MariaDB proxy (see docs/mysql.md)
 │   └── auth/                # OAuth provider abstraction (Slack, etc.)
 ├── front/                   # React frontend (see front/CLAUDE.md)
+├── website/                 # Docusaurus site for dbbat.com
+├── docs/                    # Protocol-level technical notes (oracle, mysql, dump format)
 ├── docker-compose.yml
 └── go.mod
 ```
@@ -102,11 +112,12 @@ make clean            # Clean build artifacts
 ## CLI Commands
 
 ```bash
-./dbbat              # Start server (default command)
-./dbbat serve        # Start server explicitly
-./dbbat db migrate   # Run pending migrations
-./dbbat db rollback  # Rollback last migration group
-./dbbat db status    # Show migration status
+./dbbat                            # Start server (default command)
+./dbbat serve                      # Start server explicitly
+./dbbat db migrate                 # Run pending migrations
+./dbbat db rollback                # Rollback last migration group
+./dbbat db status                  # Show migration status
+./dbbat dump anonymise <in> [out]  # Strip session metadata from a .dbbat-dump
 ```
 
 ## Environment Variables
@@ -114,16 +125,20 @@ make clean            # Clean build artifacts
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `DBB_DSN` | PostgreSQL DSN for DBBat storage | Yes |
-| `DBB_LISTEN_PG` | Proxy listen address (default: `:5434`) | No |
+| `DBB_LISTEN_PG` | PostgreSQL proxy listen address (default: `:5434`) | No |
+| `DBB_LISTEN_ORA` | Oracle proxy listen address (default: `:1522`; empty disables) | No |
+| `DBB_LISTEN_MYSQL` | MySQL/MariaDB proxy listen address (default: `:3307`; empty disables) | No |
 | `DBB_LISTEN_API` | REST API listen address (default: `:4200`) | No |
 | `DBB_KEY` | Base64-encoded AES-256 encryption key | No |
 | `DBB_KEYFILE` | Path to file containing encryption key | No |
 | `DBB_RUN_MODE` | Run mode: empty, `test`, or `demo` | No |
 | `DBB_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` (default: `info`) | No |
-| `DBB_LISTEN_ORA` | Oracle proxy listen address (default: `:1522`) | No |
 | `DBB_DUMP_DIR` | Directory for session dump files (empty = disabled) | No |
 | `DBB_DUMP_MAX_SIZE` | Max dump file size per session in bytes (default: 10MB) | No |
 | `DBB_DUMP_RETENTION` | Auto-delete dumps older than this (default: `24h`) | No |
+| `DBB_MYSQL_TLS_DISABLE` | Refuse TLS upgrade on the MySQL listener (default: `false`) | No |
+| `DBB_MYSQL_TLS_CERT_FILE` | PEM cert for MySQL TLS termination (auto self-signed if empty) | No |
+| `DBB_MYSQL_TLS_KEY_FILE` | PEM RSA key for MySQL TLS termination (auto-generated if empty) | No |
 
 Note: If no encryption key is provided, one is created at `~/.dbbat/key`.
 
@@ -156,17 +171,21 @@ Use `--bun:split` directive to split multiple statements.
 ### Connection Flow
 ```
 Client → DBBat (auth + grant check) → Target PostgreSQL
-Client → DBBat (service name lookup) → Target Oracle
+Client → DBBat (service-name lookup, O5LOGON proxy auth) → Target Oracle
+Client → DBBat (caching_sha2_password / TLS termination) → Target MySQL/MariaDB
 ```
 
+The same auth + grant + query-logging pipeline runs across all three protocols (`internal/proxy/shared`).
+
 ### Access Control
-- Time-windowed grants (starts_at, expires_at)
-- Controls: `read_only`, `block_copy`, `block_ddl`
-- Optional quotas: max queries, max bytes
+- Time-windowed grants (`starts_at`, `expires_at`)
+- Controls: `read_only`, `block_copy`, `block_ddl` (combinable; empty = full write)
+- Optional quotas: `max_query_counts`, `max_bytes_transferred`
 
 ### Security
 - User passwords: Argon2id hashed
-- Database credentials: AES-256-GCM encrypted
+- Database credentials: AES-256-GCM encrypted (AAD-bound to the database UID)
+- API keys: encrypted blobs, prefix `dbb_`; cannot create/revoke other keys
 - Default admin: `admin`/`admin` (must change on first login)
 
 ## API Documentation

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DBBat - PostgreSQL Observability Proxy
+# DBBat - Database Observability Proxy
 
 **Give your devs access to prod.**
 
-A transparent PostgreSQL proxy for query observability, access control, and safety. Every query logged. Every connection tracked.
+A transparent database proxy for query observability, access control, and safety. Speaks **PostgreSQL**, **Oracle**, and **MySQL/MariaDB** wire protocols. Every query logged. Every connection tracked.
 
 ## Documentation
 
@@ -23,19 +23,39 @@ Full documentation is available at **[dbbat.com](https://dbbat.com)**:
 
 DBBat acts as a monitoring proxy that allows controlled developer access to production databases with:
 - **Complete monitoring**: Every query and result is logged with full traceability
-- **Strict limitations**: Time-windowed access, read/write controls, query quotas, and data transfer limits
+- **Strict limitations**: Time-windowed access, fine-grained controls, query quotas, and data transfer limits
 - **Full audit trail**: Track who accessed what, when, and what data they retrieved
 - **Encrypted credentials**: Database passwords never exposed to users
 - **Granular access control**: Grant temporary access to specific databases with precise permissions
 
+## Supported Databases
+
+| Engine | Protocol | Default proxy port | Notes |
+|--------|----------|--------------------|-------|
+| PostgreSQL | PostgreSQL wire (`pgx/v5`) | `:5434` (`DBB_LISTEN_PG`) | First-class support; auth terminated at proxy |
+| Oracle | TNS / TTC | `:1522` (`DBB_LISTEN_ORA`) | O5LOGON proxy auth; `go-ora` end-to-end (other clients reach AUTH only — see [docs/oracle.md](docs/oracle.md)) |
+| MySQL | MySQL wire (`go-mysql-org/go-mysql`) | `:3307` (`DBB_LISTEN_MYSQL`) | `caching_sha2_password` (default), `mysql_clear_password`; TLS terminated at proxy |
+| MariaDB | MySQL wire (same listener) | `:3307` (`DBB_LISTEN_MYSQL`) | Same as MySQL — `mysql_native_password` not supported, `STMT_BULK_EXECUTE` refused |
+
+Each engine has its own listener; enable only the ones you need by setting the matching `DBB_LISTEN_*` environment variable. PostgreSQL is enabled by default; Oracle/MySQL listen on their default ports unless explicitly disabled in config.
+
 ## Features
 
-- **User Management**: Authenticate users with username/password, role-based access control
-- **Database Configuration**: Store target database connections with encrypted credentials
-- **Connection & Query Tracking**: Log all connections and queries with timing and results
-- **Access Control**: Time-windowed access grants with controls (`read_only`, `block_copy`, `block_ddl`) and quotas
-- **REST API**: Full API for management and observability
-- **PostgreSQL Proxy**: Transparent proxy with wire protocol support
+- **Multi-engine proxy**: PostgreSQL, Oracle, MySQL/MariaDB on independent listeners
+- **User Management**: Local user database with username/password (Argon2id) and `admin`/`viewer`/`connector` roles
+- **API Keys**: Long-lived bearer tokens (`dbb_…`) for programmatic access; cannot create or revoke other keys (security restriction)
+- **Slack OAuth (optional)**: Sign-in via Slack workspace, optional auto-provisioning
+- **Database Configuration**: Store target database connections with AES-256-GCM encrypted credentials; `protocol` field per database (`postgresql`, `oracle`, `mysql`, `mariadb`)
+- **Connection & Query Tracking**: Logs every connection, every query (SQL text, parameters, duration, rows affected, errors), and optionally captures result rows (`query_rows` table) up to configurable size limits
+- **Access Control**: Time-windowed grants (`starts_at` / `expires_at`), independent controls (`read_only`, `block_copy`, `block_ddl`), and optional quotas (`max_query_counts`, `max_bytes_transferred`)
+- **Read-only enforcement**: Defense in depth — SQL inspection, PostgreSQL `default_transaction_read_only`, MySQL/MariaDB blocks for `LOAD DATA`/`SELECT … INTO OUTFILE`/etc., and proxy-side opt-out from `LOCAL INFILE`
+- **Audit Trail**: Append-only audit log of user, grant, and database changes
+- **Rate Limiting**: Per-user request limits and exponential backoff on failed login
+- **Authentication Cache**: Optional in-memory cache (TTL + max size) shared across REST and proxy auth paths
+- **Session Packet Dumps**: Optional binary capture of post-auth session traffic (`.dbbat-dump` files); same format across all protocols (see [docs/dump-format.md](docs/dump-format.md)) with `dbbat dump anonymise` for sharing
+- **REST API**: OpenAPI 3.0 documented (`/api/docs`), versioned under `/api/v1/`
+- **Web UI**: Embedded React frontend served at `/app`
+- **Demo / Test modes**: Self-provisioning sample data for safe trials and E2E testing
 
 ## Quick Start
 
@@ -45,9 +65,13 @@ DBBat acts as a monitoring proxy that allows controlled developer access to prod
 docker run -d \
   -e DBB_DSN="postgres://user:pass@host:5432/dbbat?sslmode=require" \
   -p 5434:5434 \
-  -p 8080:8080 \
+  -p 1522:1522 \
+  -p 3307:3307 \
+  -p 4200:4200 \
   ghcr.io/fclairamb/dbbat
 ```
+
+Ports: `5434` PostgreSQL proxy, `1522` Oracle proxy, `3307` MySQL/MariaDB proxy, `4200` REST API + web UI.
 
 ### Running with Docker Compose
 
@@ -60,7 +84,7 @@ All API endpoints are under `/api/v1/`. See the [API Reference](https://dbbat.co
 ### 1. Login and get a token
 
 ```bash
-TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:4200/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "admin", "password": "admin"}' | jq -r '.token')
 ```
@@ -68,7 +92,7 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \
 ### 2. Create a User
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/users \
+curl -X POST http://localhost:4200/api/v1/users \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -81,12 +105,13 @@ curl -X POST http://localhost:8080/api/v1/users \
 ### 3. Configure a Target Database
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/databases \
+curl -X POST http://localhost:4200/api/v1/databases \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "production",
     "description": "Production database",
+    "protocol": "postgresql",
     "host": "db.example.com",
     "port": 5432,
     "database_name": "myapp",
@@ -96,10 +121,12 @@ curl -X POST http://localhost:8080/api/v1/databases \
   }'
 ```
 
+For Oracle, set `"protocol": "oracle"` and add `"oracle_service_name": "ORCL"`. For MySQL/MariaDB, set `"protocol": "mysql"` (or `"mariadb"`) and use port `3306`.
+
 ### 4. Grant Access
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/grants \
+curl -X POST http://localhost:4200/api/v1/grants \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -113,10 +140,20 @@ curl -X POST http://localhost:8080/api/v1/grants \
   }'
 ```
 
+`controls` accepts any combination of `read_only`, `block_copy`, `block_ddl`. An empty array means full write access.
+
 ### 5. Connect via Proxy
 
 ```bash
+# PostgreSQL
 psql -h localhost -p 5434 -U developer -d production
+
+# Oracle (go-ora-style easy connect)
+# Use the database name (or its oracle_service_name) as SERVICE_NAME
+# Example with sqlplus: developer/temppass123@//localhost:1522/production
+
+# MySQL / MariaDB
+mysql -h 127.0.0.1 -P 3307 -u developer -p production
 ```
 
 ## Configuration
@@ -124,33 +161,49 @@ psql -h localhost -p 5434 -U developer -d production
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `DBB_DSN` | PostgreSQL DSN for DBBat storage | Required |
-| `DBB_LISTEN_PG` | Proxy listen address | `:5434` |
-| `DBB_LISTEN_API` | REST API listen address | `:8080` |
-| `DBB_KEY` | Base64-encoded AES-256 encryption key | Auto-generated |
+| `DBB_LISTEN_PG` | PostgreSQL proxy listen address | `:5434` |
+| `DBB_LISTEN_ORA` | Oracle proxy listen address (empty disables) | `:1522` |
+| `DBB_LISTEN_MYSQL` | MySQL/MariaDB proxy listen address (empty disables) | `:3307` |
+| `DBB_LISTEN_API` | REST API listen address | `:4200` |
+| `DBB_KEY` | Base64-encoded AES-256 encryption key | Auto-generated at `~/.dbbat/key` |
 | `DBB_KEYFILE` | Path to file containing encryption key | - |
-| `DBB_RUN_MODE` | Run mode: empty, `test`, or `demo` | - |
+| `DBB_RUN_MODE` | Run mode: empty (production), `test`, or `demo` | - |
+| `DBB_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `info` |
+| `DBB_DUMP_DIR` | Directory for session packet dumps (empty disables) | - |
+| `DBB_DUMP_MAX_SIZE` | Max dump file size per session, in bytes | `10485760` (10 MB) |
+| `DBB_DUMP_RETENTION` | Auto-delete dumps older than this (Go duration) | `24h` |
+| `DBB_MYSQL_TLS_DISABLE` | Disable MySQL TLS termination at the proxy | `false` |
+| `DBB_MYSQL_TLS_CERT_FILE` | PEM cert for MySQL TLS (auto self-signed if empty) | - |
+| `DBB_MYSQL_TLS_KEY_FILE` | PEM RSA key for MySQL TLS (auto-generated if empty) | - |
 
-See [Configuration](https://dbbat.com/docs/configuration) for all options.
+See [Configuration](https://dbbat.com/docs/configuration) for the full set, including rate limiting, query storage, hash presets, auth cache, Slack OAuth, demo target, and dev redirects.
 
 ## Security
 
 - User passwords are hashed with Argon2id
-- Database credentials are encrypted with AES-256-GCM
-- Default admin user (username: `admin`, password: `admin`) is created on first startup - **change this immediately!**
+- Database credentials are encrypted with AES-256-GCM (AAD-bound to the database UID)
+- API keys (`dbb_…`) are stored as encrypted blobs and cannot create or revoke other keys
+- Failed logins trigger per-username exponential backoff
+- Default admin user (`admin` / `admin`) is created on first startup — **change it immediately**
 
 ## Architecture
 
 ```
-Client -> DBBat (auth + grant check) -> Target PostgreSQL
+psql / pg client     ─►  DBBat (auth + grant check + log) ─► PostgreSQL upstream
+sqlplus / go-ora     ─►  DBBat (TNS service-name routing)  ─► Oracle upstream
+mysql / mariadb cli  ─►  DBBat (caching_sha2_password)     ─► MySQL / MariaDB upstream
 ```
+
+DBBat is a single Go binary backed by a PostgreSQL store (users, databases, grants, connections, queries, audit, dumps).
 
 ## Development
 
 ```bash
-make dev          # Start dev environment with hot reload
-make test         # Run tests
+make dev          # Start dev environment with hot reload (Air + Vite)
+make test         # Run Go tests (uses testcontainers)
+make test-e2e     # Run Playwright E2E tests
 make build-app    # Build frontend + backend
-make lint         # Run linter
+make lint         # Run golangci-lint
 ```
 
 See [CLAUDE.md](CLAUDE.md) for development documentation.

--- a/docs/api.md
+++ b/docs/api.md
@@ -197,7 +197,7 @@ curl -X POST http://localhost:8080/api/v1/grants \
   -d "{
     \"user_id\": \"$USER_UID\",
     \"database_id\": \"$DB_UID\",
-    \"access_level\": \"read\",
+    \"controls\": [\"read_only\"],
     \"starts_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
     \"expires_at\": \"$(date -u -d '+24 hours' +%Y-%m-%dT%H:%M:%SZ)\",
     \"max_query_counts\": 1000

--- a/website/docs/api/index.md
+++ b/website/docs/api/index.md
@@ -11,8 +11,10 @@ DBBat provides a comprehensive REST API for managing users, databases, grants, a
 All API endpoints are versioned under `/api/v1/`:
 
 ```
-http://localhost:8080/api/v1
+http://localhost:4200/api/v1
 ```
+
+(The default API listen address is `:4200` — `DBB_LISTEN_API`. Adjust the host/port to your deployment.)
 
 ## OpenAPI Specification
 
@@ -30,7 +32,7 @@ The API supports two authentication methods:
 HTTP Basic Authentication using username and password:
 
 ```bash
-curl -u username:password http://localhost:8080/api/v1/users
+curl -u username:password http://localhost:4200/api/v1/users
 ```
 
 ### Bearer Token
@@ -38,7 +40,7 @@ curl -u username:password http://localhost:8080/api/v1/users
 API key or web session token authentication:
 
 ```bash
-curl -H "Authorization: Bearer <token>" http://localhost:8080/api/v1/users
+curl -H "Authorization: Bearer <token>" http://localhost:4200/api/v1/users
 ```
 
 :::note
@@ -92,7 +94,7 @@ Rate-limited authentication attempts receive a `429 Too Many Requests` response 
 List endpoints support pagination with `limit` and `offset` parameters:
 
 ```bash
-curl -u admin:password "http://localhost:8080/api/v1/queries?limit=100&offset=0"
+curl -u admin:password "http://localhost:4200/api/v1/queries?limit=100&offset=0"
 ```
 
 | Parameter | Default | Min | Max | Description |
@@ -463,6 +465,7 @@ Creates a new database configuration. **Requires admin role.**
 {
   "name": "production-main",
   "description": "Main production database",
+  "protocol": "postgresql",
   "host": "db.example.com",
   "port": 5432,
   "database_name": "myapp",
@@ -472,6 +475,8 @@ Creates a new database configuration. **Requires admin role.**
 }
 ```
 
+`protocol` accepts `postgresql` (default), `oracle`, `mysql`, or `mariadb`. For Oracle, also provide `oracle_service_name` so TNS clients can route by service name.
+
 **Response:**
 
 ```json
@@ -479,11 +484,13 @@ Creates a new database configuration. **Requires admin role.**
   "uid": "550e8400-e29b-41d4-a716-446655440000",
   "name": "production-main",
   "description": "Main production database",
+  "protocol": "postgresql",
   "host": "db.example.com",
   "port": 5432,
   "database_name": "myapp",
   "username": "app_user",
   "ssl_mode": "require",
+  "oracle_service_name": null,
   "created_by": "660e8400-e29b-41d4-a716-446655440000"
 }
 ```
@@ -498,7 +505,7 @@ Returns a list of database configurations. Response varies by role:
 
 | Role | Response |
 |------|----------|
-| Admin | Full details (host, port, database_name, username, ssl_mode) |
+| Admin | Full details (host, port, database_name, username, ssl_mode, protocol, oracle_service_name) |
 | Viewer | Limited info (uid, name, description) |
 | Connector | Only databases with active grants (limited info) |
 
@@ -554,13 +561,23 @@ Creates a new access grant for a user to a database. **Requires admin role.**
 {
   "user_id": "550e8400-e29b-41d4-a716-446655440000",
   "database_id": "660e8400-e29b-41d4-a716-446655440000",
-  "access_level": "read",
+  "controls": ["read_only"],
   "starts_at": "2024-01-01T00:00:00Z",
   "expires_at": "2024-12-31T23:59:59Z",
   "max_query_counts": 10000,
   "max_bytes_transferred": 1073741824
 }
 ```
+
+`controls` is an array. Each element is one of:
+
+| Value | Effect |
+|-------|--------|
+| `read_only` | SQL inspection blocks writes; PostgreSQL also sets `default_transaction_read_only = on`. |
+| `block_copy` | Blocks `COPY` (PostgreSQL) and `LOAD DATA` / `SELECT … INTO OUTFILE` (MySQL). |
+| `block_ddl` | Blocks `CREATE`, `ALTER`, `DROP`, `TRUNCATE`. |
+
+An empty `controls` array (or omitting the field) grants full write access within the time window.
 
 **Response:**
 
@@ -569,7 +586,7 @@ Creates a new access grant for a user to a database. **Requires admin role.**
   "uid": "770e8400-e29b-41d4-a716-446655440000",
   "user_id": "550e8400-e29b-41d4-a716-446655440000",
   "database_id": "660e8400-e29b-41d4-a716-446655440000",
-  "access_level": "read",
+  "controls": ["read_only"],
   "granted_by": "880e8400-e29b-41d4-a716-446655440000",
   "starts_at": "2024-01-01T00:00:00Z",
   "expires_at": "2024-12-31T23:59:59Z",

--- a/website/docs/configuration/databases.md
+++ b/website/docs/configuration/databases.md
@@ -4,75 +4,120 @@ sidebar_position: 2
 
 # Database Configuration
 
-Target databases are configured through the REST API. Each database configuration maps a DBBat database name to a target PostgreSQL server.
+Target databases are configured through the REST API. Each entry maps a DBBat database name to a target server (PostgreSQL, Oracle, MySQL, or MariaDB).
 
 ## Creating a Database Configuration
 
+### PostgreSQL
+
 ```bash
-curl -u admin:admin -X POST http://localhost:8080/api/databases \
+curl -X POST http://localhost:4200/api/v1/databases \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "production",
+    "description": "Production PostgreSQL",
+    "protocol": "postgresql",
     "host": "prod-db.example.com",
     "port": 5432,
+    "database_name": "myapp",
     "username": "app_user",
     "password": "secret",
-    "database": "myapp",
-    "ssl_mode": "require",
-    "description": "Production database"
+    "ssl_mode": "require"
   }'
 ```
+
+### Oracle
+
+```bash
+curl -X POST http://localhost:4200/api/v1/databases \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "orcl",
+    "description": "Oracle 19c",
+    "protocol": "oracle",
+    "host": "oracle.example.com",
+    "port": 1521,
+    "database_name": "ORCL",
+    "oracle_service_name": "ORCL",
+    "username": "scott",
+    "password": "tiger",
+    "ssl_mode": "disable"
+  }'
+```
+
+`oracle_service_name` is what TNS clients use to route to this entry. It can match `database_name` or be different (e.g. for PDB names).
+
+### MySQL / MariaDB
+
+```bash
+curl -X POST http://localhost:4200/api/v1/databases \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "shop",
+    "description": "Production MySQL",
+    "protocol": "mysql",
+    "host": "mysql.example.com",
+    "port": 3306,
+    "database_name": "shop",
+    "username": "app_user",
+    "password": "secret",
+    "ssl_mode": "prefer"
+  }'
+```
+
+For MariaDB, set `"protocol": "mariadb"`. Both share the same listener and proxy code path; the protocol field controls UI labelling and default-port hints.
 
 ## Fields
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
-| `name` | string | DBBat database name (used in connection string) | Yes |
-| `host` | string | Target PostgreSQL host | Yes |
-| `port` | integer | Target PostgreSQL port | Yes (default: 5432) |
+| `name` | string | DBBat database name (used by clients in their connection string) | Yes |
+| `protocol` | enum | `postgresql`, `oracle`, `mysql`, `mariadb` | No (default: `postgresql`) |
+| `host` | string | Target database host | Yes |
+| `port` | integer | Target database port. Suggested defaults: 5432 / 1521 / 3306. | Yes |
+| `database_name` | string | Target database name (or PDB name for Oracle) | Yes (PG/MySQL); recommended (Oracle) |
 | `username` | string | Target database username | Yes |
 | `password` | string | Target database password (encrypted at rest) | Yes |
-| `database` | string | Target database name | Yes |
-| `ssl_mode` | string | SSL mode for target connection | No (default: `disable`) |
+| `ssl_mode` | string | SSL mode for the upstream connection | No (default: `prefer`) |
+| `oracle_service_name` | string | Oracle SERVICE_NAME — used to route TNS connects | Recommended for Oracle |
 | `description` | string | Human-readable description | No |
 
 ## SSL Modes
 
-- `disable` - No SSL connection
-- `require` - Use SSL, don't verify certificate
-- `verify-ca` - Verify server certificate against CA
-- `verify-full` - Verify certificate and hostname match
+These follow the libpq convention and apply to the **upstream** connection:
+
+- `disable` — No SSL
+- `prefer` — Try SSL, fall back to plain (default)
+- `require` — Require SSL, don't verify certificate
+- `verify-ca` — Verify server certificate against CA
+- `verify-full` — Verify certificate and hostname match
+
+Client-side TLS for the proxy listeners is configured separately (e.g. `DBB_MYSQL_TLS_*` for the MySQL listener).
 
 ## Listing Databases
 
 ```bash
-curl -u admin:admin http://localhost:8080/api/databases
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4200/api/v1/databases
 ```
 
-Response:
+Response visibility depends on the caller's role:
 
-```json
-[
-  {
-    "id": 1,
-    "name": "production",
-    "host": "prod-db.example.com",
-    "port": 5432,
-    "username": "app_user",
-    "database": "myapp",
-    "ssl_mode": "require",
-    "description": "Production database",
-    "created_at": "2024-01-15T10:30:00Z"
-  }
-]
-```
+| Role | What they see |
+|------|---------------|
+| Admin | Full details (host, port, database_name, username, ssl_mode, protocol, oracle_service_name) |
+| Viewer | Limited (uid, name, description) |
+| Connector | Only databases they have an active grant for (limited fields) |
 
-Note: Passwords are never returned in API responses.
+Passwords are **never** returned in any response.
 
 ## Updating a Database
 
 ```bash
-curl -u admin:admin -X PUT http://localhost:8080/api/databases/1 \
+curl -X PUT http://localhost:4200/api/v1/databases/$DB_UID \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "description": "Updated description",
@@ -80,24 +125,32 @@ curl -u admin:admin -X PUT http://localhost:8080/api/databases/1 \
   }'
 ```
 
-Only provide fields you want to update.
+Provide only the fields you want to update. Changing `password` re-encrypts the credential.
 
 ## Deleting a Database
 
 ```bash
-curl -u admin:admin -X DELETE http://localhost:8080/api/databases/1
+curl -X DELETE http://localhost:4200/api/v1/databases/$DB_UID \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
-Deleting a database configuration will:
-- Prevent new connections to that database
-- Not affect existing active connections
-- Not delete any logged queries or connections
+Deleting a database configuration:
+
+- Prevents new connections to that database
+- Does not affect existing active connections
+- Preserves all logged queries and connection history (for audit)
 
 ## Connection Flow
 
 When a user connects with `database=production`:
 
-1. DBBat looks up the database configuration named `production`
-2. Decrypts the stored credentials
-3. Connects to the target server using those credentials
-4. Proxies all queries between client and target
+1. **PostgreSQL / MySQL**: DBBat looks up the entry by `name` (the database name in the client's connection string).
+2. **Oracle**: DBBat matches the TNS connect descriptor's `SERVICE_NAME` against `oracle_service_name` (falls back to `name`).
+3. DBBat decrypts the stored credentials.
+4. DBBat verifies the user has an active, non-revoked grant for this database.
+5. DBBat connects to the upstream using the stored credentials.
+6. DBBat proxies all subsequent queries between client and target, logging everything.
+
+## Storage-DSN Collision Warning
+
+DBBat warns at startup if a configured target's `host:port/database_name` matches the DBBat storage DSN. Allowing developers to proxy *into* DBBat's own store is a privilege-escalation vector — keep them on separate databases (preferably separate clusters).

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -4,33 +4,114 @@ sidebar_position: 1
 
 # Configuration Overview
 
-DBBat is configured using environment variables, configuration files, or CLI flags.
+DBBat is configured via environment variables, an optional configuration file (YAML/JSON/TOML), or CLI flags.
 
 ## Priority Order
 
-Configuration is loaded in this priority order (highest to lowest):
+Configuration is loaded in this priority order (highest wins):
+
 1. CLI flags
-2. Environment variables
-3. Configuration file
-4. Default values
+2. Environment variables (`DBB_…`)
+3. Configuration file (`--config`, or `DBB_CONFIG=` env var)
+4. Built-in defaults
 
 ## Environment Variables
 
-| Variable | Description | Default | Required |
-|----------|-------------|---------|----------|
-| `DBB_DSN` | PostgreSQL DSN for DBBat storage | - | Yes |
-| `DBB_LISTEN_PG` | Proxy listen address | `:5434` | No |
-| `DBB_LISTEN_API` | REST API listen address | `:8080` | No |
-| `DBB_KEY` | Base64-encoded AES-256 encryption key | Auto-generated | No |
-| `DBB_KEYFILE` | Path to file containing encryption key | - | No |
-| `DBB_BASE_URL` | Base URL path for the frontend app | `/app` | No |
-| `DBB_RUN_MODE` | Run mode: empty, `test`, or `demo` | - | No |
-| `DBB_REDIRECTS` | Dev redirect rules for proxying to dev servers | - | No |
-| `DBB_DEMO_TARGET_DB` | Allowed database target in demo mode | `demo:demo@localhost/demo` | No |
+### Required
 
-:::note
-If no encryption key is provided via `DBB_KEY` or `DBB_KEYFILE`, DBBat automatically generates one and stores it at `~/.dbbat/key`.
-:::
+| Variable | Description |
+|----------|-------------|
+| `DBB_DSN` | PostgreSQL DSN for DBBat's own storage (users, grants, queries, audit, …) |
+
+### Listeners
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_LISTEN_PG` | PostgreSQL proxy listen address | `:5434` |
+| `DBB_LISTEN_ORA` | Oracle proxy listen address. Empty value disables the Oracle proxy. | `:1522` |
+| `DBB_LISTEN_MYSQL` | MySQL/MariaDB proxy listen address. Empty value disables it. | `:3307` |
+| `DBB_LISTEN_API` | REST API + web UI listen address | `:4200` |
+
+### Encryption Key
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_KEY` | Base64-encoded 32-byte AES-256 key | Auto-generated |
+| `DBB_KEYFILE` | Path to a file containing the encryption key | - |
+
+If neither is set, DBBat generates a key on first start and writes it to `~/.dbbat/key` (mode `0600`, parent dir `0700`). Losing this key means the encrypted database credentials cannot be recovered.
+
+### Run Mode & Logging
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_RUN_MODE` | `` (production), `test`, or `demo` | `` |
+| `DBB_LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `info` |
+| `DBB_BASE_URL` | Base URL path the frontend is served under | `/app` |
+| `DBB_REDIRECTS` | Dev-only redirect rules (`/path:host:port[/target]`, comma-separated) | - |
+| `DBB_DEMO_TARGET_DB` | Demo-mode allowed target (`user:pass@host/dbname`) | `demo:demo@localhost/demo` |
+
+### Session Packet Dumps
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_DUMP_DIR` | Directory for `.dbbat-dump` files. Empty = disabled. | _disabled_ |
+| `DBB_DUMP_MAX_SIZE` | Max dump file size per session, in bytes | `10485760` (10 MB) |
+| `DBB_DUMP_RETENTION` | Auto-delete dumps older than this (Go duration) | `24h` |
+
+See [Session Packet Dumps](/docs/features/session-dumps) for what gets captured.
+
+### MySQL Proxy TLS
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_MYSQL_TLS_DISABLE` | Refuse `SSLRequest` packets and stay plaintext-only | `false` |
+| `DBB_MYSQL_TLS_CERT_FILE` | PEM-encoded server certificate | _auto self-signed_ |
+| `DBB_MYSQL_TLS_KEY_FILE` | PEM-encoded RSA private key (RSA required for the non-TLS `caching_sha2` public-key path) | _auto-generated RSA-2048_ |
+
+### Query Result Storage
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_QUERY_STORAGE_STORE_RESULTS` | Globally enable result-row capture | `true` |
+| `DBB_QUERY_STORAGE_MAX_RESULT_ROWS` | Max rows captured per query | `100000` |
+| `DBB_QUERY_STORAGE_MAX_RESULT_BYTES` | Max bytes captured per query | `104857600` (100 MB) |
+
+### Rate Limiting
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_RATE_LIMIT_ENABLED` | Enable per-user/IP rate limiting | `true` |
+| `DBB_RATE_LIMIT_REQUESTS_PER_MINUTE` | Requests per minute per authenticated user | `60` |
+| `DBB_RATE_LIMIT_REQUESTS_PER_MINUTE_ANON` | Requests per minute per source IP (unauthenticated) | `10` |
+| `DBB_RATE_LIMIT_BURST` | Short-burst tolerance | `10` |
+
+### Password Hashing (Argon2id)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_HASH_PRESET` | One of `default`, `low`, `minimal` | `default` |
+| `DBB_HASH_MEMORY_MB` | Memory cost (1–1024 MB) | `64` |
+| `DBB_HASH_TIME` | Time cost (1–10) | `1` |
+| `DBB_HASH_THREADS` | Parallelism (1–16) | `4` |
+
+### Auth Cache
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_AUTH_CACHE_ENABLED` | Cache auth results across REST + proxies | `true` |
+| `DBB_AUTH_CACHE_TTL_SECONDS` | Cache entry TTL | `300` |
+| `DBB_AUTH_CACHE_MAX_SIZE` | Maximum cache entries | `10000` |
+
+### Slack OAuth (optional)
+
+| Variable | Description |
+|----------|-------------|
+| `DBB_SLACK_AUTH_CLIENT_ID` | Slack app client ID |
+| `DBB_SLACK_AUTH_CLIENT_SECRET` | Slack app client secret |
+| `DBB_SLACK_AUTH_TEAM_ID` | Restrict sign-in to one workspace |
+| `DBB_SLACK_AUTH_AUTO_CREATE_USERS` | Auto-provision new users (default `true`) |
+| `DBB_SLACK_AUTH_DEFAULT_ROLE` | Role assigned to auto-provisioned users (default `connector`) |
 
 ## Configuration File
 
@@ -40,8 +121,37 @@ DBBat supports YAML, JSON, and TOML configuration files.
 
 ```yaml
 listen_pg: ":5434"
-listen_api: ":8080"
+listen_ora: ":1522"
+listen_mysql: ":3307"
+listen_api: ":4200"
 dsn: "postgres://user:pass@localhost:5432/dbbat?sslmode=require"
+
+query_storage:
+  store_results: true
+  max_result_rows: 100000
+  max_result_bytes: 104857600
+
+rate_limit:
+  enabled: true
+  requests_per_minute: 60
+  burst: 10
+
+dump:
+  dir: "/var/dbbat/dumps"
+  max_size: 33554432
+  retention: "72h"
+
+mysql:
+  tls:
+    disable: false
+    cert_file: "/etc/dbbat/mysql.crt"
+    key_file: "/etc/dbbat/mysql.key"
+
+slack_auth:
+  client_id: "..."
+  client_secret: "..."
+  auto_create_users: true
+  default_role: "connector"
 ```
 
 Load with the `--config` flag:
@@ -50,33 +160,21 @@ Load with the `--config` flag:
 dbbat serve --config /etc/dbbat/config.yaml
 ```
 
-## Encryption Key
+## Generating an Encryption Key
 
-DBBat requires a 32-byte encryption key for encrypting database credentials. If not provided, one is automatically generated.
+DBBat requires a 32-byte AES-256 key for encrypting database credentials. If neither `DBB_KEY` nor `DBB_KEYFILE` is set, DBBat generates one at `~/.dbbat/key` and reuses it on subsequent starts.
 
-### Generate a Key
+To generate one yourself:
 
 ```bash
 openssl rand -base64 32
 ```
 
-### Using Environment Variable
-
-```bash
-export DBB_KEY="YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY="
-```
-
-### Using Key File
-
-```bash
-openssl rand 32 > /etc/dbbat/key
-chmod 600 /etc/dbbat/key
-export DBB_KEYFILE="/etc/dbbat/key"
-```
+Use it as `DBB_KEY=…` or write it to a file referenced by `DBB_KEYFILE=`.
 
 ## Storage Database
 
-DBBat stores its configuration and logs in a PostgreSQL database. You need to provide a DSN to this database.
+DBBat stores its configuration and logs in a PostgreSQL database. Provide the DSN via `DBB_DSN`.
 
 ### DSN Format
 
@@ -86,32 +184,40 @@ postgres://user:password@host:port/database?sslmode=require
 
 ### SSL Modes
 
-- `disable` - No SSL
-- `require` - Require SSL but don't verify certificate
-- `verify-ca` - Require SSL and verify CA
-- `verify-full` - Require SSL and verify CA + hostname
+- `disable` — No SSL
+- `require` — Require SSL but don't verify certificate
+- `verify-ca` — Require SSL and verify CA
+- `verify-full` — Require SSL and verify CA + hostname
+
+:::warning Security
+DBBat warns at startup if any configured target database matches the storage DSN — sharing a database for storage and proxying enables privilege escalation. Use a separate database (or a separate cluster) for DBBat's own storage.
+:::
 
 ## Run Modes
 
 ### Test Mode (`DBB_RUN_MODE=test`)
 
 Useful for E2E testing and development:
-- Wipes all data on startup
-- Creates admin user with password `admintest`
-- Creates sample users: `viewer`, `connector`
-- Creates sample database and grants
+
+- Wipes all DBBat-owned tables on startup
+- Recreates admin with password `admintest` (already password-changed)
+- Creates `viewer` (role `viewer`) and `connector` (role `connector`) users
+- Creates a sample target database, plus stable API keys (`dbb_admin_key`, `dbb_viewer_key`, `dbb_connector_key`)
 
 ### Demo Mode (`DBB_RUN_MODE=demo`)
 
 For public demos with restricted database targets:
-- Wipes all data on startup
-- Creates admin user with password `admin`
+
+- Wipes all DBBat-owned tables on startup
+- Creates admin/viewer/connector users with their username as the password
 - Only allows database configurations matching `DBB_DEMO_TARGET_DB`
+- Defaults to `demo:demo@localhost/demo`
 
 ## Default Admin
 
-On first startup, DBBat creates a default admin user:
+On first startup (in production mode), DBBat creates a default admin user:
+
 - **Username**: `admin`
 - **Password**: `admin`
 
-**Important**: Change this password immediately after first login.
+The password is flagged as requiring change. Login attempts return `403 password_change_required` until the admin calls `PUT /api/v1/auth/password` to set a real password.

--- a/website/docs/features/access-control.md
+++ b/website/docs/features/access-control.md
@@ -4,21 +4,22 @@ sidebar_position: 1
 
 # Access Control
 
-DBBat provides fine-grained access control through grants. A grant gives a user permission to access a specific database for a limited time with optional quotas.
+DBBat provides fine-grained access control through **grants**. A grant gives a user permission to access a specific database for a limited time, optionally with one or more controls and quotas.
 
 ## Creating a Grant
 
 ```bash
-curl -u admin:admin -X POST http://localhost:8080/api/grants \
+curl -X POST http://localhost:4200/api/v1/grants \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "user_id": 2,
-    "database_id": 1,
-    "access_level": "read",
+    "user_id": "550e8400-e29b-41d4-a716-446655440000",
+    "database_id": "660e8400-e29b-41d4-a716-446655440000",
+    "controls": ["read_only"],
     "starts_at": "2024-01-15T09:00:00Z",
     "expires_at": "2024-01-15T18:00:00Z",
-    "max_queries": 1000,
-    "max_bytes": 104857600
+    "max_query_counts": 1000,
+    "max_bytes_transferred": 104857600
   }'
 ```
 
@@ -26,32 +27,53 @@ curl -u admin:admin -X POST http://localhost:8080/api/grants \
 
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
-| `user_id` | integer | ID of the user | Yes |
-| `database_id` | integer | ID of the database configuration | Yes |
-| `access_level` | string | `read` or `write` | Yes |
+| `user_id` | UUID | UID of the user | Yes |
+| `database_id` | UUID | UID of the database configuration | Yes |
+| `controls` | array | Combination of `read_only`, `block_copy`, `block_ddl`. Empty = full write access. | No (default: `[]`) |
 | `starts_at` | datetime | When the grant becomes active | Yes |
-| `expires_at` | datetime | When the grant expires | Yes |
-| `max_queries` | integer | Maximum number of queries allowed | No |
-| `max_bytes` | integer | Maximum bytes transferred | No |
+| `expires_at` | datetime | When the grant expires (must be after `starts_at`) | Yes |
+| `max_query_counts` | integer | Maximum number of queries allowed | No |
+| `max_bytes_transferred` | integer | Maximum bytes transferred (response size) | No |
 
-## Access Levels
+The grant model is the same across all engines (PostgreSQL, Oracle, MySQL/MariaDB).
 
-### Read
+## Controls
 
-Read-only access prevents any write operations:
-- `SELECT` queries are allowed
-- `INSERT`, `UPDATE`, `DELETE`, `DROP`, `TRUNCATE`, `CREATE`, `ALTER`, `GRANT`, `REVOKE` are blocked
+Controls are **independent** and **combinable**. A grant with `["read_only", "block_copy", "block_ddl"]` enforces all three. An empty array allows full write access — including DDL, COPY, and writes — within the grant's time window.
 
-### Write
+### `read_only`
 
-Full read/write access allows all query types.
+Blocks every operation that mutates data, in **defense-in-depth**:
+
+- **Layer 1 — SQL inspection** (all engines): regex blocks `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `REPLACE`, `CREATE`, `ALTER`, `DROP`, `TRUNCATE`, `GRANT`, `REVOKE`, plus `COPY FROM` (PostgreSQL) and `LOAD DATA` / `SELECT … INTO OUTFILE` (MySQL).
+- **Layer 2 — engine session flag**:
+  - **PostgreSQL**: `SET SESSION default_transaction_read_only = on` at session start.
+  - **MySQL/MariaDB**: regex inspection only — `SET SESSION TRANSACTION READ ONLY` only applies to the *next* transaction in MySQL and is trivially bypassable.
+  - **Oracle**: regex inspection only.
+- **Layer 3 — bypass prevention** (PostgreSQL): attempts to disable read-only mode are blocked (`SET default_transaction_read_only = off`, `RESET …`, `SET SESSION AUTHORIZATION`, `SET ROLE`).
+
+`read_only` is defense in depth for **trusted users**, not a security boundary against malicious actors. For untrusted access, also limit privileges on the upstream database user (e.g. PostgreSQL `GRANT SELECT` only).
+
+### `block_copy`
+
+Blocks all bulk file-touching operations:
+
+- **PostgreSQL**: `COPY … TO` and `COPY … FROM` (both directions).
+- **MySQL/MariaDB**: `LOAD DATA INFILE`, `SELECT … INTO OUTFILE`, `SELECT … INTO DUMPFILE`. Note that `LOAD DATA LOCAL INFILE` is **always** refused (see the MySQL notes).
+
+### `block_ddl`
+
+Blocks schema changes: `CREATE`, `ALTER`, `DROP`, `TRUNCATE`.
+
+Useful when you need write access (for support intervention, data fixes) but want to prevent accidental schema drift.
 
 ## Time Windows
 
 Grants are only active within their time window:
-- Before `starts_at`: Connection refused
-- Between `starts_at` and `expires_at`: Access granted
-- After `expires_at`: Connection refused
+
+- Before `starts_at`: connection refused
+- Between `starts_at` and `expires_at`: access granted
+- After `expires_at`: connection refused
 
 This is useful for:
 - Support engineers who need temporary access
@@ -62,64 +84,65 @@ This is useful for:
 
 ### Query Quota
 
-Limit the number of queries a user can execute:
+Limit the number of queries a grant can execute:
 
 ```json
-{
-  "max_queries": 100
-}
+{ "max_query_counts": 100 }
 ```
 
 When exceeded, subsequent queries return an error.
 
 ### Data Transfer Quota
 
-Limit the amount of data transferred:
+Limit the volume of data returned through the proxy:
 
 ```json
-{
-  "max_bytes": 104857600
-}
+{ "max_bytes_transferred": 104857600 }
 ```
 
-When exceeded, subsequent queries return an error. This is calculated based on the response size from the database.
+When exceeded, subsequent queries return an error. The byte counter accumulates response sizes from the upstream database.
+
+Counters (`query_count`, `bytes_transferred`) are exposed on the grant object so admins can see usage in real time.
 
 ## Revoking Grants
 
 Manually revoke a grant before expiration:
 
 ```bash
-curl -u admin:admin -X DELETE http://localhost:8080/api/grants/1
+curl -X DELETE http://localhost:4200/api/v1/grants/$GRANT_UID \
+  -H "Authorization: Bearer $TOKEN"
 ```
+
+The grant record is preserved for audit (with `revoked_at` and `revoked_by` populated); only new connections are refused.
 
 ## Listing Grants
 
 List all grants:
 
 ```bash
-curl -u admin:admin http://localhost:8080/api/grants
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4200/api/v1/grants
 ```
 
-Filter by user:
+Filter by user, database, or active state:
 
 ```bash
-curl -u admin:admin "http://localhost:8080/api/grants?user_id=2"
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/grants?user_id=$USER_UID&active_only=true"
+
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/grants?database_id=$DB_UID"
 ```
 
-Filter by database:
-
-```bash
-curl -u admin:admin "http://localhost:8080/api/grants?database_id=1"
-```
+Connectors only see their own grants; admins and viewers see all.
 
 ## Audit Trail
 
 All grant operations are logged in the audit log:
-- Grant creation (who granted, to whom, which database)
+- Grant creation (who granted, to whom, which database, what controls and quotas)
 - Grant revocation (who revoked, when)
 
 View the audit log:
 
 ```bash
-curl -u admin:admin http://localhost:8080/api/audit
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4200/api/v1/audit
 ```

--- a/website/docs/features/query-logging.md
+++ b/website/docs/features/query-logging.md
@@ -4,104 +4,125 @@ sidebar_position: 2
 
 # Query Logging
 
-DBBat logs all queries executed through the proxy, providing complete visibility into database activity.
+DBBat logs every query executed through the proxy — across all supported engines (PostgreSQL, Oracle, MySQL, MariaDB) — providing complete visibility into database activity.
 
 ## What's Logged
 
 For each query, DBBat records:
 
-- **SQL text**: The complete query as sent by the client
-- **User**: Which DBBat user executed the query
-- **Database**: Which target database the query ran against
-- **Connection**: The connection ID (links to connection metadata)
-- **Start time**: When the query started
-- **Duration**: How long the query took (in milliseconds)
-- **Rows affected**: Number of rows returned or modified
-- **Result data**: Optionally, the actual result rows
+- **SQL text**: the complete query as sent by the client (or the prepared statement text for binary protocols)
+- **Parameters**: bound parameters for prepared/extended-query statements (PostgreSQL extended query, MySQL `COM_STMT_EXECUTE`)
+- **User**: which DBBat user executed the query
+- **Database**: which target database the query ran against
+- **Connection**: the connection UID (links to connection metadata)
+- **Started at**: when the query started
+- **Duration**: how long the query took (milliseconds)
+- **Rows affected**: number of rows returned or modified
+- **Error**: error text if the query failed
+- **Result rows**: optionally captured up to `query_storage.max_result_rows` / `max_result_bytes`
+
+### Engine-specific notes
+
+- **PostgreSQL**: both Simple Query (`Q`) and Extended Query (`P`/`B`/`E`) are logged. Parameter values are stored as JSONB.
+- **MySQL / MariaDB**: text protocol (`COM_QUERY`) and binary protocol (`COM_STMT_EXECUTE`) are decoded and stored uniformly. `COM_INIT_DB` is logged as `USE <db>`. `COM_PING` / `COM_QUIT` are not logged.
+- **Oracle**: SQL is parsed out of TTC `Execute` (function `0x03`, sub-op `0x5e`) packets. Row capture works for `SELECT` results decoded from the first response and continuation packets; DML row counts are not captured from v315+ responses.
 
 ## Viewing Queries
 
 List recent queries:
 
 ```bash
-curl -u admin:admin http://localhost:8080/api/queries
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/queries"
 ```
 
 ### Filtering
 
-By user:
-
 ```bash
-curl -u admin:admin "http://localhost:8080/api/queries?user_id=2"
-```
+# By user
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/queries?user_id=$USER_UID"
 
-By database:
+# By database
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/queries?database_id=$DB_UID"
 
-```bash
-curl -u admin:admin "http://localhost:8080/api/queries?database_id=1"
-```
+# By time range (RFC 3339)
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/queries?start_time=2024-01-15T00:00:00Z&end_time=2024-01-16T00:00:00Z"
 
-By time range:
-
-```bash
-curl -u admin:admin "http://localhost:8080/api/queries?from=2024-01-15T00:00:00Z&to=2024-01-16T00:00:00Z"
-```
-
-Combined filters:
-
-```bash
-curl -u admin:admin "http://localhost:8080/api/queries?user_id=2&database_id=1&from=2024-01-15T00:00:00Z"
+# By connection
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/queries?connection_id=$CONN_UID"
 ```
 
 ## Query Details
 
-Get full details including result rows:
+Get a single query (without rows):
 
 ```bash
-curl -u admin:admin http://localhost:8080/api/queries/123
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4200/api/v1/queries/$QUERY_UID
 ```
 
 Response:
 
 ```json
 {
-  "id": 123,
-  "connection_id": 45,
-  "sql": "SELECT id, name FROM users WHERE active = true",
-  "started_at": "2024-01-15T10:30:00Z",
-  "duration_ms": 42,
+  "uid": "550e8400-e29b-41d4-a716-446655440000",
+  "connection_id": "660e8400-e29b-41d4-a716-446655440000",
+  "sql_text": "SELECT id, name FROM users WHERE active = $1",
+  "parameters": {
+    "values": ["true"],
+    "format_codes": [0],
+    "type_oids": [16]
+  },
+  "executed_at": "2024-01-15T10:30:00Z",
+  "duration_ms": 12.5,
   "rows_affected": 5,
-  "user": {
-    "id": 2,
-    "username": "analyst"
-  },
-  "database": {
-    "id": 1,
-    "name": "production"
-  },
-  "rows": [
-    {"id": 1, "name": "Alice"},
-    {"id": 2, "name": "Bob"},
-    {"id": 3, "name": "Charlie"},
-    {"id": 4, "name": "Diana"},
-    {"id": 5, "name": "Eve"}
-  ]
+  "error": null
 }
 ```
+
+## Query Result Rows
+
+Result rows are stored separately and fetched on demand with cursor-based pagination — capped at 1000 rows or 1 MB per response, whichever comes first.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:4200/api/v1/queries/$QUERY_UID/rows?limit=100"
+```
+
+Response:
+
+```json
+{
+  "rows": [
+    { "row_number": 0, "row_data": {"id": 1, "name": "Alice"}, "row_size_bytes": 32 }
+  ],
+  "next_cursor": "eyJvZmZzZXQiOjEwMH0=",
+  "has_more": true,
+  "total_rows": 500
+}
+```
+
+Pass the `next_cursor` value back as `?cursor=…` to fetch the next page.
 
 ## Connection Tracking
 
 Queries are linked to connections. View connection details:
 
 ```bash
-curl -u admin:admin http://localhost:8080/api/connections
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4200/api/v1/connections
 ```
 
 Connection metadata includes:
 - Source IP address
-- Connected user
+- Connecting user
 - Target database
-- Connection start/end time
+- Connection start, last-activity, and disconnect timestamps
+- Aggregated query count and bytes transferred
 
 ## Use Cases
 
@@ -115,7 +136,7 @@ Track all database access for compliance:
 ### Performance Analysis
 
 Identify slow queries:
-- Sort by duration
+- Sort by `duration_ms`
 - Find patterns in slow queries
 - Analyze query frequency
 
@@ -123,12 +144,12 @@ Identify slow queries:
 
 Troubleshoot application issues:
 - See exactly what queries your application runs
-- Verify query parameters
-- Check timing and sequencing
+- Verify parameter values for prepared statements
+- Check timing and sequencing across engines
 
 ### Data Access Review
 
 Regular reviews of who accessed sensitive data:
-- Filter by specific tables or keywords
+- Filter by table or keyword in `sql_text`
 - Time-boxed reports
 - User activity summaries

--- a/website/docs/features/session-dumps.md
+++ b/website/docs/features/session-dumps.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 4
+---
+
+# Session Packet Dumps
+
+DBBat can write **per-session binary dumps** of every proxied connection. The dump captures the post-auth byte stream between client and upstream, which is invaluable for protocol-level debugging, replay testing, and forensic analysis.
+
+The format is **protocol-agnostic**: PostgreSQL, Oracle, and MySQL/MariaDB sessions all use the same `.dbbat-dump` file structure. See the [full format spec](https://github.com/fclairamb/dbbat/blob/main/docs/dump-format.md) for the on-disk layout.
+
+## Enabling Dumps
+
+Dumps are **disabled by default**. Set `DBB_DUMP_DIR` to enable, optionally tuning size and retention.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_DUMP_DIR` | Directory for `.dbbat-dump` files. Empty = disabled. | _disabled_ |
+| `DBB_DUMP_MAX_SIZE` | Max bytes per session file. When the next packet would exceed this, it's silently skipped and an EOF marker is written. | `10485760` (10 MB) |
+| `DBB_DUMP_RETENTION` | Auto-delete dumps older than this Go duration (`24h`, `7d`, `1h30m`, …). | `24h` |
+
+```bash
+docker run -d \
+  -e DBB_DSN=... \
+  -e DBB_DUMP_DIR=/var/dbbat/dumps \
+  -e DBB_DUMP_MAX_SIZE=33554432 \
+  -e DBB_DUMP_RETENTION=72h \
+  -v dbbat-dumps:/var/dbbat/dumps \
+  ghcr.io/fclairamb/dbbat
+```
+
+Each session writes a single file named `<connection-uid>.dbbat-dump`.
+
+## What's Captured
+
+The dump records the **post-authentication command stream** only:
+
+- The MySQL/PostgreSQL/Oracle handshake and auth phase are **not** captured. Credentials, scrambles, and challenge data never reach the dump.
+- TLS-upgraded connections (MySQL TLS termination) capture **TLS records** as they pass through the tap point — packet boundaries and timing are preserved, but contents are encrypted.
+- Each packet records its direction (client→server / server→client), nanoseconds since session start, and raw bytes.
+
+## File Format Highlights
+
+```
+┌──────────────────────────────────────────┐
+│ Magic (DBBAT_DUMP)         16 bytes      │
+│ Format version              2 bytes      │
+│ JSON header length          4 bytes      │
+├──────────────────────────────────────────┤
+│ JSON header (session metadata)           │
+├──────────────────────────────────────────┤
+│ Packet 1   [13-byte frame] [data]        │
+│ Packet 2   [13-byte frame] [data]        │
+│ …                                        │
+│ EOF marker [13-byte frame, dir=0xFF]     │
+└──────────────────────────────────────────┘
+```
+
+The JSON header carries protocol-specific metadata (e.g. PostgreSQL `database`/`user`, Oracle `service_name`, upstream address). Readers must tolerate unknown keys — the format is forward-compatible.
+
+## Anonymising a Dump for Sharing
+
+Before sharing a dump (with vendors, support, an open-source maintainer), strip the connection metadata:
+
+```bash
+dbbat dump anonymise capture.dbbat-dump
+# writes capture.anonymised.dbbat-dump
+
+dbbat dump anonymise capture.dbbat-dump out.dbbat-dump
+# explicit output path
+```
+
+The packet stream is preserved verbatim; only the JSON header is rewritten to remove identifying fields.
+
+## Use Cases
+
+- **Protocol-level debugging**: replay a captured Oracle TNS handshake to investigate `ORA-` errors, or diff two MySQL `caching_sha2_password` flows.
+- **Regression tests**: feed a dump into the proxy's replay tests (see `internal/proxy/oracle/dump_replay_test.go` for an example).
+- **Forensics**: confirm exactly which queries a compromised user ran, byte-for-byte, including any non-printable payload.
+
+## Operational Notes
+
+- Dumps disable themselves cleanly at process shutdown — the EOF marker is always written so partial captures remain readable.
+- The `max_size` limit is enforced per file. There's no global cap, so monitor the dump directory growth and rely on `retention` for cleanup.
+- For TLS-terminated MySQL connections, the tap sits **after** auth termination, so the dump sees plaintext command-phase traffic.

--- a/website/docs/features/supported-databases.md
+++ b/website/docs/features/supported-databases.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 0
+---
+
+# Supported Databases
+
+DBBat ships with three independent listeners — one per wire protocol family. Enable only the engines you need by setting the matching `DBB_LISTEN_*` variable; an empty value disables that proxy.
+
+| Engine | Protocol | Default proxy port | Env var | Status |
+|--------|----------|--------------------|---------|--------|
+| PostgreSQL | PostgreSQL wire (`pgx/v5`) | `:5434` | `DBB_LISTEN_PG` | First-class. Auth terminated at the proxy. MD5 and SCRAM clients work transparently. |
+| Oracle | TNS / TTC | `:1522` | `DBB_LISTEN_ORA` | Hand-rolled TTC parser. End-to-end with `go-ora`; other clients reach AUTH but cannot yet execute queries (see notes below). |
+| MySQL | MySQL wire (`go-mysql-org/go-mysql`) | `:3307` | `DBB_LISTEN_MYSQL` | `caching_sha2_password` (default), `mysql_clear_password`. TLS terminated at the proxy. `mysql_native_password` not supported. |
+| MariaDB | MySQL wire (same listener) | `:3307` | `DBB_LISTEN_MYSQL` | Shares the MySQL listener. `STMT_BULK_EXECUTE` is refused — clients need batch-rewriting disabled. |
+
+The same auth + grant + query-logging pipeline runs across all three protocols, so:
+
+- **One user store** (Argon2id passwords, roles, optional Slack OAuth) authenticates against any engine.
+- **One database catalogue** holds target connections; a `protocol` field marks the engine.
+- **One grant model** applies the same controls (`read_only`, `block_copy`, `block_ddl`) and quotas regardless of upstream engine.
+- **One query log** records every statement (`COM_QUERY`, `COM_STMT_EXECUTE`, PostgreSQL Simple/Extended Query, Oracle TTC Execute) in the same `queries` table.
+- **One dump format** captures session traffic for any engine — see [the dump-format spec](https://github.com/fclairamb/dbbat/blob/main/docs/dump-format.md).
+
+## PostgreSQL
+
+The reference implementation. Both authentication and command-phase traffic are inspected.
+
+- **Auth termination**: clients authenticate against the DBBat user store; DBBat re-authenticates upstream using the encrypted credentials in the database catalogue.
+- **Read-only enforcement** is layered:
+  1. Regex SQL inspection blocks `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `CREATE`, `ALTER`, `DROP`, `TRUNCATE`, `GRANT`, `REVOKE`, `COPY FROM`, `CALL`.
+  2. The proxy issues `SET SESSION default_transaction_read_only = on` at session start.
+  3. Attempts to disable read-only (`SET …`, `RESET`, `SET ROLE`, `SET SESSION AUTHORIZATION`) are blocked.
+- **Result rows** are captured up to `query_storage.max_result_rows` / `max_result_bytes`.
+
+## Oracle
+
+Implemented as a hand-rolled TNS/TTC proxy in `internal/proxy/oracle`. See the full [protocol notes](https://github.com/fclairamb/dbbat/blob/main/docs/oracle.md) for wire-level details.
+
+- **Connection routing** uses the `SERVICE_NAME` from the TNS connect descriptor — match it against either the database `name` or its `oracle_service_name`.
+- **Auth**: dbbat speaks O5LOGON to the client (per-user verifier loaded from an API key). The upstream session is re-authenticated using the database's stored credentials.
+- **Query extraction**: SQL is parsed out of TTC `Execute` (function `0x03`, sub-op `0x5e`) packets; result rows are decoded for the first response (`func=0x10`) and continuation packets (`func=0x06`).
+- **Number/Date decoding**: Oracle `NUMBER` and `DATE` formats are decoded for row capture.
+
+### Tested clients
+
+| Client | Status |
+|--------|--------|
+| `go-ora` | SQL + rows work end-to-end |
+| Python `oracledb` (thin) | Authenticates; client rejects captured AUTH OK with `DPY-4035` |
+| `ojdbc11` / DBeaver | SQL works, row capture partial |
+| SQLcl 23c+ | Reaches AUTH; client rejects captured AUTH OK with `ORA-17401` |
+| `sqlplus` (OCI) | Not yet supported (NS protocol not implemented; fails with `ORA-12630`) |
+
+For now, use `go-ora` (or older thin-driver clients) end-to-end.
+
+## MySQL & MariaDB
+
+Implemented in `internal/proxy/mysql` on top of `go-mysql-org/go-mysql`. See the full [MySQL notes](https://github.com/fclairamb/dbbat/blob/main/docs/mysql.md) for protocol-level details.
+
+- **Auth termination**: `caching_sha2_password` is advertised by default. The fast-auth scramble is intentionally unused — every login takes the full-auth path so the cleartext password can be verified against the Argon2id hash (over TLS or RSA-OAEP).
+- **TLS**: terminated at the proxy. `DBB_MYSQL_TLS_CERT_FILE` / `_KEY_FILE` provide the cert; if empty, a self-signed cert and RSA-2048 keypair are generated at startup.
+- **`mysql_clear_password`**: accepted as a fallback for clients that explicitly pin to it.
+- **`mysql_native_password`**: not supported (Argon2id is one-way; we cannot derive the SHA1 nested hash).
+- **API key auth**: a "password" prefixed with `dbb_` is verified as an API key.
+
+### Always-blocked operations (regardless of grant)
+
+| Operation | Why |
+|-----------|-----|
+| `LOAD DATA INFILE` | Reads files from the MySQL server filesystem |
+| `LOAD DATA LOCAL INFILE` | Server can request the client to upload arbitrary local files. Refused at SQL level *and* via `CLIENT_LOCAL_FILES` capability opt-out on the upstream connection. |
+| `SELECT … INTO OUTFILE` / `INTO DUMPFILE` | Server-side filesystem write |
+| `COM_BINLOG_DUMP` / `COM_REGISTER_SLAVE` | Replication protocol — would let a client tail the binlog |
+| `COM_SHUTDOWN` / `COM_PROCESS_KILL` / `COM_DEBUG` | Privileged server operations |
+| `STMT_BULK_EXECUTE` (MariaDB) | Not supported by go-mysql server side; refused |
+
+### Logged commands
+
+| MySQL command | Logged as |
+|---------------|-----------|
+| `COM_QUERY` | SQL text |
+| `COM_STMT_PREPARE` | `PREPARE: <sql>` (logged once at prepare time) |
+| `COM_STMT_EXECUTE` | The previously-prepared SQL with parameters in `parameters` JSONB |
+| `COM_INIT_DB` | `USE <db>` synthetic SQL |
+| `COM_PING`, `COM_QUIT`, `COM_STMT_RESET`, `COM_STMT_CLOSE` | Not logged (housekeeping / keepalive noise) |
+
+### Tested clients
+
+| Client | Library | Status |
+|--------|---------|--------|
+| Go | `go-sql-driver/mysql` | Full coverage in CI |
+| MySQL CLI | `mysql` 8.x | Manual smoke test |
+| Python | PyMySQL | Manual smoke test |
+| MariaDB CLI | `mariadb` 10.x | Manual smoke test |
+
+## Picking a Port
+
+Default ports are chosen to avoid colliding with a co-located database server:
+
+| Service | Default port |
+|---------|--------------|
+| PostgreSQL proxy | 5434 (PostgreSQL itself usually binds 5432) |
+| Oracle proxy | 1522 (Oracle listener usually binds 1521) |
+| MySQL/MariaDB proxy | 3307 (MySQL/MariaDB usually bind 3306) |
+| REST API + web UI | 4200 |
+
+Override any of them with the matching `DBB_LISTEN_*` environment variable.

--- a/website/docs/features/user-management.md
+++ b/website/docs/features/user-management.md
@@ -6,21 +6,34 @@ sidebar_position: 3
 
 DBBat maintains its own user database, separate from target database users. This separation provides:
 
-- Independent credentials for proxy access
-- Central user management across multiple databases
+- Independent credentials for proxy access (one DBBat login, many target databases)
+- Central user management across PostgreSQL, Oracle, and MySQL/MariaDB targets
 - Audit trail of user actions
+
+## Roles
+
+Each user carries one or more roles. Roles are **additive**.
+
+| Role | Description |
+|------|-------------|
+| `admin` | Full access to all resources and operations |
+| `viewer` | Read-only access to observability data (connections, queries, audit) |
+| `connector` | Can only connect through the proxy to databases with active grants |
+
+A user can have multiple roles (e.g. `["admin", "connector"]` so an admin can also connect through the proxy).
 
 ## Creating Users
 
-Create a new user via the REST API:
+Create a new user via the REST API. **Admin role required.**
 
 ```bash
-curl -u admin:admin -X POST http://localhost:8080/api/users \
+curl -X POST http://localhost:4200/api/v1/users \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "username": "analyst",
-    "password": "secure-password",
-    "is_admin": false
+    "username": "developer",
+    "password": "TempPassword123!",
+    "roles": ["connector"]
   }'
 ```
 
@@ -29,81 +42,120 @@ curl -u admin:admin -X POST http://localhost:8080/api/users \
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
 | `username` | string | Unique username | Yes |
-| `password` | string | User password (hashed with Argon2id) | Yes |
-| `is_admin` | boolean | Whether user has admin privileges | No (default: false) |
+| `password` | string | Initial user password (hashed with Argon2id) | Yes |
+| `roles` | array | Any combination of `admin`, `viewer`, `connector` | No (default: `["connector"]`) |
 
-## Admin vs Regular Users
-
-### Regular Users
-
-- Can connect through the proxy (with valid grants)
-- Can view their own connections and queries
-- Cannot manage other users, databases, or grants
-
-### Admin Users
-
-- All regular user capabilities
-- Create/modify/delete users
-- Create/modify/delete database configurations
-- Create/revoke grants
-- View all connections, queries, and audit logs
+The user's initial password must be **changed before first login** — see "Initial password change" below.
 
 ## Listing Users
 
 ```bash
-curl -u admin:admin http://localhost:8080/api/users
+curl -H "Authorization: Bearer $TOKEN" http://localhost:4200/api/v1/users
 ```
 
-Response:
+Admins see all users; non-admins see only themselves.
 
 ```json
-[
-  {
-    "id": 1,
-    "username": "admin",
-    "is_admin": true,
-    "created_at": "2024-01-01T00:00:00Z"
-  },
-  {
-    "id": 2,
-    "username": "analyst",
-    "is_admin": false,
-    "created_at": "2024-01-15T10:00:00Z"
-  }
-]
+{
+  "users": [
+    {
+      "uid": "550e8400-e29b-41d4-a716-446655440000",
+      "username": "admin",
+      "roles": ["admin"],
+      "rate_limit_exempt": true,
+      "created_at": "2024-01-01T00:00:00Z",
+      "updated_at": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
 ```
 
 ## Updating Users
 
-Update user details (admin only, or self for password):
+```bash
+curl -X PUT http://localhost:4200/api/v1/users/$USER_UID \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "roles": ["admin", "connector"] }'
+```
+
+- Non-admins can only update their own password
+- Non-admins cannot change roles
+- API keys cannot change passwords (Basic Auth or web session required)
+
+## Changing Passwords
+
+Authenticated password change (the user re-supplies their current credentials in the body):
 
 ```bash
-curl -u admin:admin -X PUT http://localhost:8080/api/users/2 \
+curl -X PUT http://localhost:4200/api/v1/users/$USER_UID/password \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "password": "new-secure-password"
+    "username": "developer",
+    "current_password": "TempPassword123!",
+    "new_password": "EvenBetterPassword456!"
   }'
 ```
+
+## Initial Password Change
+
+Newly created users (and the default `admin`) must change their password **before logging in**. Login attempts return `403 password_change_required`. The pre-login change endpoint accepts the username and current password without an auth header:
+
+```bash
+curl -X PUT http://localhost:4200/api/v1/auth/password \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "developer",
+    "current_password": "TempPassword123!",
+    "new_password": "EvenBetterPassword456!"
+  }'
+```
+
+## API Keys
+
+For programmatic access, create a long-lived API key (`dbb_…`) instead of using a username/password.
+
+```bash
+curl -X POST http://localhost:4200/api/v1/keys \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "ci-pipeline", "expires_at": "2025-12-31T23:59:59Z" }'
+```
+
+The full key is **only returned once**. Store it securely.
+
+API keys carry their owner's roles, but with two intentional restrictions:
+
+- They **cannot create** other API keys.
+- They **cannot revoke** API keys.
+
+These operations require Basic Auth or a web session token. This prevents a leaked API key from being used to bootstrap persistent backdoor access.
+
+API keys can also be used as the password against the proxy listeners (PostgreSQL, MySQL, Oracle) — DBBat detects the `dbb_` prefix and verifies it as a key.
+
+## Slack OAuth (optional)
+
+When configured, users can sign in with their Slack workspace account. New users are auto-provisioned by default with the `connector` role. Configurable via:
+
+- `slack_auth.client_id` / `slack_auth.client_secret`
+- `slack_auth.team_id` (optional — restrict to one workspace)
+- `slack_auth.auto_create_users` (default `true`)
+- `slack_auth.default_role` (default `connector`)
 
 ## Deleting Users
 
 ```bash
-curl -u admin:admin -X DELETE http://localhost:8080/api/users/2
+curl -X DELETE http://localhost:4200/api/v1/users/$USER_UID \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 Deleting a user:
 - Revokes all their active grants
-- Preserves their query and connection history for audit
+- Preserves their query, connection, and audit history
 - Prevents any future connections
 
-## Password Requirements
-
-While DBBat doesn't enforce specific password policies, we recommend:
-
-- Minimum 12 characters
-- Mix of letters, numbers, and symbols
-- Unique passwords per user
-- Regular rotation for sensitive environments
+You cannot delete your own account.
 
 ## Default Admin
 
@@ -111,10 +163,4 @@ On first startup, DBBat creates:
 - **Username**: `admin`
 - **Password**: `admin`
 
-**Important**: Change this password immediately:
-
-```bash
-curl -u admin:admin -X PUT http://localhost:8080/api/users/1 \
-  -H "Content-Type: application/json" \
-  -d '{"password": "your-secure-password"}'
-```
+The password is flagged as requiring change — the very first login will fail with `403 password_change_required` until you call `PUT /api/v1/auth/password` to set a real password.

--- a/website/docs/installation/binary.md
+++ b/website/docs/installation/binary.md
@@ -8,17 +8,19 @@ You can also run DBBat directly as a binary.
 
 ## Download
 
-Download the latest release from [GitHub Releases](https://github.com/fclairamb/dbbat/releases).
+Download the latest release from [GitHub Releases](https://github.com/fclairamb/dbbat/releases). Builds are produced via goreleaser for Linux/macOS on amd64 and arm64.
 
 ## Building from Source
 
-Ensure you have Go 1.21+ installed:
+Ensure you have Go 1.26+ and Bun (for the embedded frontend). Then:
 
 ```bash
 git clone https://github.com/fclairamb/dbbat.git
 cd dbbat
-go build -o dbbat ./cmd/dbbat
+make build-app   # builds frontend + backend, embeds the UI in the binary
 ```
+
+The resulting binary is at `./dbbat`.
 
 ## Running
 
@@ -29,37 +31,68 @@ export DBB_KEY="your-base64-encoded-key"
 ./dbbat serve
 ```
 
+By default, DBBat listens on:
+
+| Service | Address |
+|---------|---------|
+| PostgreSQL proxy | `:5434` |
+| Oracle proxy | `:1522` |
+| MySQL / MariaDB proxy | `:3307` |
+| REST API + web UI | `:4200` |
+
+Set `DBB_LISTEN_*=""` to disable a listener you don't need.
+
 ## CLI Commands
 
 ```bash
-# Start DBBat server (default)
+# Start the server (default action)
 ./dbbat
 ./dbbat serve
 
-# Database migration commands
-./dbbat db migrate   # Run pending migrations
-./dbbat db rollback  # Rollback last migration group
-./dbbat db status    # Show migration status
+# Database migrations
+./dbbat db migrate    # Run pending migrations
+./dbbat db rollback   # Rollback the last migration group
+./dbbat db status     # Show migration status
+
+# Dump utilities
+./dbbat dump anonymise capture.dbbat-dump            # writes capture.anonymised.dbbat-dump
+./dbbat dump anonymise capture.dbbat-dump out.dump   # explicit output path
+```
+
+CLI flags override env vars; env vars override the config file. Common flags:
+
+```bash
+./dbbat serve \
+  --listen-addr :5434 \
+  --api-addr :4200 \
+  --dsn "postgres://user:pass@localhost:5432/dbbat" \
+  --keyfile /etc/dbbat/key
 ```
 
 ## Configuration File
 
-DBBat supports YAML configuration files:
+DBBat supports YAML, JSON, and TOML configuration files:
 
 ```yaml
-# dbbat.yaml
+# /etc/dbbat/config.yaml
 listen_pg: ":5434"
-listen_api: ":8080"
+listen_ora: ":1522"
+listen_mysql: ":3307"
+listen_api: ":4200"
 dsn: "postgres://user:pass@localhost:5432/dbbat"
+
+dump:
+  dir: "/var/dbbat/dumps"
+  retention: "72h"
 ```
 
 Load with:
 
 ```bash
-./dbbat serve --config dbbat.yaml
+./dbbat serve --config /etc/dbbat/config.yaml
 ```
 
-Priority order: CLI flags > Environment variables > Config file > Defaults
+Priority order: **CLI flags > environment variables > config file > defaults**.
 
 ## Systemd Service
 
@@ -67,7 +100,7 @@ Create `/etc/systemd/system/dbbat.service`:
 
 ```ini
 [Unit]
-Description=DBBat PostgreSQL Proxy
+Description=DBBat Database Observability Proxy
 After=network.target postgresql.service
 
 [Service]
@@ -79,6 +112,10 @@ Restart=on-failure
 RestartSec=5
 Environment=DBB_DSN=postgres://user:pass@localhost:5432/dbbat
 Environment=DBB_KEYFILE=/etc/dbbat/key
+Environment=DBB_LISTEN_PG=:5434
+Environment=DBB_LISTEN_ORA=:1522
+Environment=DBB_LISTEN_MYSQL=:3307
+Environment=DBB_LISTEN_API=:4200
 
 [Install]
 WantedBy=multi-user.target
@@ -87,8 +124,7 @@ WantedBy=multi-user.target
 Enable and start:
 
 ```bash
-sudo systemctl enable dbbat
-sudo systemctl start dbbat
+sudo systemctl enable --now dbbat
 ```
 
 ## Next Steps

--- a/website/docs/installation/docker-compose.md
+++ b/website/docs/installation/docker-compose.md
@@ -30,18 +30,24 @@ services:
       DBB_DSN: postgres://dbbat:dbbat@postgres:5432/dbbat?sslmode=disable
       DBB_KEY: ${DBB_KEY:-YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=}
       DBB_LISTEN_PG: ":5434"
-      DBB_LISTEN_API: ":8080"
+      DBB_LISTEN_ORA: ":1522"
+      DBB_LISTEN_MYSQL: ":3307"
+      DBB_LISTEN_API: ":4200"
     ports:
-      - "5001:5434"  # Proxy port
-      - "8080:8080"  # API port
+      - "5001:5434"   # PostgreSQL proxy
+      - "1522:1522"   # Oracle proxy
+      - "3307:3307"   # MySQL / MariaDB proxy
+      - "4200:4200"   # REST API + web UI
 
 volumes:
   postgres_data:
 ```
 
+Drop any `DBB_LISTEN_*`/port pair you don't need — set the variable to an empty string to disable that proxy entirely.
+
 ## Initial Setup Script (init.sql)
 
-Create a `init.sql` file to set up a sample target database:
+Create an `init.sql` file to set up a sample target database:
 
 ```sql
 -- Create a target database for testing
@@ -67,28 +73,38 @@ INSERT INTO test_data (name, value) VALUES
 Start the services:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Login and Get a Token
 
 ```bash
-# Login to get a session token
-TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:4200/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "admin", "password": "admin"}' | jq -r '.token')
 ```
 
-### Create a Database Configuration
+:::note
+On first start the default admin password is flagged as requiring change. Call `PUT /api/v1/auth/password` to set a real password before logging in:
 
 ```bash
-# First, configure the target database
-curl -X POST http://localhost:8080/api/v1/databases \
+curl -X PUT http://localhost:4200/api/v1/auth/password \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","current_password":"admin","new_password":"NewSecurePass!"}'
+```
+:::
+
+### Configure a Target Database
+
+```bash
+# PostgreSQL target
+curl -X POST http://localhost:4200/api/v1/databases \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "target_db",
     "description": "Target database for testing",
+    "protocol": "postgresql",
     "host": "postgres",
     "port": 5432,
     "database_name": "target",
@@ -98,48 +114,67 @@ curl -X POST http://localhost:8080/api/v1/databases \
   }'
 ```
 
+For Oracle add `"protocol": "oracle"` plus `"oracle_service_name": "ORCL"`. For MySQL/MariaDB use `"protocol": "mysql"` (or `"mariadb"`) and port `3306`.
+
 ### Create a Test User and Grant Access
 
 ```bash
-# Create a test user
-curl -X POST http://localhost:8080/api/v1/users \
+# Create the user
+USER_UID=$(curl -s -X POST http://localhost:4200/api/v1/users \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"username": "testuser", "password": "testpass", "roles": ["connector"]}'
+  -d '{"username": "testuser", "password": "testpass", "roles": ["connector"]}' \
+  | jq -r '.uid')
 
-# Get the user UID and database UID from the responses above, then create a grant
-curl -X POST http://localhost:8080/api/v1/grants \
+# Activate the user (one-time pre-login password set)
+curl -X PUT http://localhost:4200/api/v1/auth/password \
+  -H "Content-Type: application/json" \
+  -d '{"username":"testuser","current_password":"testpass","new_password":"newtestpass"}'
+
+# Get the database UID
+DB_UID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4200/api/v1/databases | jq -r '.databases[0].uid')
+
+# Create a grant (empty controls = full write access)
+curl -X POST http://localhost:4200/api/v1/grants \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "<user-uid>",
-    "database_id": "<database-uid>",
-    "controls": [],
-    "starts_at": "2024-01-01T00:00:00Z",
-    "expires_at": "2030-01-01T00:00:00Z"
-  }'
+  -d "{
+    \"user_id\": \"$USER_UID\",
+    \"database_id\": \"$DB_UID\",
+    \"controls\": [],
+    \"starts_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
+    \"expires_at\": \"2030-01-01T00:00:00Z\"
+  }"
 ```
 
 :::note
-An empty `controls` array means full write access. Use `["read_only"]` for read-only access.
+An empty `controls` array means full write access. Use `["read_only"]` for read-only access, or combine `["read_only", "block_copy", "block_ddl"]`.
 :::
 
 ### Connect Through the Proxy
 
 ```bash
-PGPASSWORD=testpass psql -h localhost -p 5001 -U testuser -d target_db
+# PostgreSQL
+PGPASSWORD=newtestpass psql -h localhost -p 5001 -U testuser -d target_db
+
+# MySQL / MariaDB (against a MySQL target)
+mysql -h 127.0.0.1 -P 3307 -u testuser -p target_db
+
+# Oracle (against an Oracle target — using go-ora-style easy connect)
+# user/pass@//localhost:1522/target_db
 ```
 
 ## Stopping
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 To also remove volumes:
 
 ```bash
-docker-compose down -v
+docker compose down -v
 ```
 
 ## Next Steps

--- a/website/docs/installation/docker.md
+++ b/website/docs/installation/docker.md
@@ -12,21 +12,36 @@ The easiest way to run DBBat is with Docker.
 docker run -d \
   --name dbbat \
   -p 5434:5434 \
-  -p 8080:8080 \
+  -p 1522:1522 \
+  -p 3307:3307 \
+  -p 4200:4200 \
   -e DBB_DSN="postgres://user:pass@host:5432/dbbat" \
   -e DBB_KEY="your-base64-encoded-key" \
   ghcr.io/fclairamb/dbbat
 ```
 
+The same container exposes all four listeners — PostgreSQL, Oracle, MySQL/MariaDB, and the REST API + web UI. Drop the `-p` mapping for any proxy you don't need, and disable that listener with the matching `DBB_LISTEN_*=""` env var.
+
 ## Environment Variables
+
+### Core
 
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `DBB_DSN` | PostgreSQL DSN for DBBat storage | Yes |
-| `DBB_KEY` | Base64-encoded AES-256 encryption key | One of KEY/KEYFILE |
-| `DBB_KEYFILE` | Path to file containing encryption key | One of KEY/KEYFILE |
-| `DBB_LISTEN_PG` | Proxy listen address (default: `:5434`) | No |
-| `DBB_LISTEN_API` | REST API listen address (default: `:8080`) | No |
+| `DBB_KEY` | Base64-encoded AES-256 encryption key | One of `KEY`/`KEYFILE` (auto-generated if neither) |
+| `DBB_KEYFILE` | Path to file containing encryption key | One of `KEY`/`KEYFILE` |
+
+### Listeners
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DBB_LISTEN_PG` | PostgreSQL proxy listen address | `:5434` |
+| `DBB_LISTEN_ORA` | Oracle proxy listen address (empty = disabled) | `:1522` |
+| `DBB_LISTEN_MYSQL` | MySQL/MariaDB proxy listen address (empty = disabled) | `:3307` |
+| `DBB_LISTEN_API` | REST API + web UI listen address | `:4200` |
+
+For the full list (rate limiting, dump capture, MySQL TLS, hashing, Slack OAuth), see [Configuration](/docs/configuration).
 
 ## Generating an Encryption Key
 
@@ -36,10 +51,16 @@ Generate a secure 32-byte key:
 openssl rand -base64 32
 ```
 
+If you don't provide one via `DBB_KEY` or `DBB_KEYFILE`, DBBat creates one at `~/.dbbat/key` (inside the container) on first start. Mount that path as a volume to keep it across restarts.
+
 ## Exposed Ports
 
-- **5434**: PostgreSQL proxy port
-- **8080**: REST API port
+| Port | Purpose |
+|------|---------|
+| `5434` | PostgreSQL proxy |
+| `1522` | Oracle proxy |
+| `3307` | MySQL / MariaDB proxy |
+| `4200` | REST API + web UI |
 
 ## Volumes
 
@@ -48,11 +69,23 @@ For persistent key storage, mount a volume:
 ```bash
 docker run -d \
   --name dbbat \
-  -p 5434:5434 \
-  -p 8080:8080 \
+  -p 5434:5434 -p 1522:1522 -p 3307:3307 -p 4200:4200 \
   -e DBB_DSN="postgres://user:pass@host:5432/dbbat" \
   -e DBB_KEYFILE="/keys/dbbat.key" \
   -v /path/to/keys:/keys:ro \
+  ghcr.io/fclairamb/dbbat
+```
+
+To enable session packet dumps:
+
+```bash
+docker run -d \
+  --name dbbat \
+  -p 5434:5434 -p 1522:1522 -p 3307:3307 -p 4200:4200 \
+  -e DBB_DSN="postgres://user:pass@host:5432/dbbat" \
+  -e DBB_DUMP_DIR="/var/dbbat/dumps" \
+  -e DBB_DUMP_RETENTION="72h" \
+  -v dbbat-dumps:/var/dbbat/dumps \
   ghcr.io/fclairamb/dbbat
 ```
 
@@ -61,7 +94,7 @@ docker run -d \
 DBBat exposes a health endpoint:
 
 ```bash
-curl http://localhost:8080/api/v1/health
+curl http://localhost:4200/api/v1/health
 ```
 
 ## Next Steps

--- a/website/docs/installation/kubernetes.md
+++ b/website/docs/installation/kubernetes.md
@@ -6,12 +6,27 @@ sidebar_position: 4
 
 Deploy DBBat on Kubernetes with a Deployment, Service, and Ingress.
 
+A Helm chart is also maintained in-tree under [`charts/`](https://github.com/fclairamb/dbbat/tree/main/charts) — the manifests below show what the chart produces, in case you want to apply them directly.
+
 ## Prerequisites
 
 - Kubernetes cluster (1.19+)
 - kubectl configured
 - PostgreSQL database accessible from the cluster
 - Ingress controller installed (e.g., nginx-ingress, traefik)
+
+## Listeners
+
+DBBat exposes four listeners by default. Each can be disabled by setting the matching environment variable to an empty string.
+
+| Listener | Default port | Env var |
+|----------|-------------|---------|
+| PostgreSQL proxy | `5434` | `DBB_LISTEN_PG` |
+| Oracle proxy | `1522` | `DBB_LISTEN_ORA` |
+| MySQL/MariaDB proxy | `3307` | `DBB_LISTEN_MYSQL` |
+| REST API + web UI | `4200` | `DBB_LISTEN_API` |
+
+The wire protocols (PostgreSQL, Oracle TNS, MySQL) generally cannot share an HTTP Ingress — see "Exposing the proxy listeners" below for the options.
 
 ## Encryption Key Management
 
@@ -140,8 +155,14 @@ spec:
         - name: postgres
           containerPort: 5434
           protocol: TCP
+        - name: oracle
+          containerPort: 1522
+          protocol: TCP
+        - name: mysql
+          containerPort: 3307
+          protocol: TCP
         - name: api
-          containerPort: 8080
+          containerPort: 4200
           protocol: TCP
         env:
         - name: DBB_DSN
@@ -156,8 +177,12 @@ spec:
               key: encryption-key
         - name: DBB_LISTEN_PG
           value: ":5434"
+        - name: DBB_LISTEN_ORA
+          value: ":1522"
+        - name: DBB_LISTEN_MYSQL
+          value: ":3307"
         - name: DBB_LISTEN_API
-          value: ":8080"
+          value: ":4200"
         resources:
           requests:
             memory: "32Mi"
@@ -211,8 +236,16 @@ spec:
     port: 5434
     targetPort: postgres
     protocol: TCP
+  - name: oracle
+    port: 1522
+    targetPort: oracle
+    protocol: TCP
+  - name: mysql
+    port: 3307
+    targetPort: mysql
+    protocol: TCP
   - name: api
-    port: 8080
+    port: 4200
     targetPort: api
     protocol: TCP
   type: ClusterIP
@@ -281,9 +314,9 @@ spec:
               name: api
 ```
 
-## Exposing the PostgreSQL Proxy
+## Exposing the Proxy Listeners
 
-The PostgreSQL proxy port (5434) typically cannot be exposed via standard HTTP Ingress. Options include:
+The proxy listeners (PostgreSQL `5434`, Oracle `1522`, MySQL/MariaDB `3307`) cannot be exposed via a standard HTTP Ingress — they speak TCP/wire protocols, not HTTP. Options:
 
 ### Option 1: LoadBalancer Service
 
@@ -292,7 +325,7 @@ The PostgreSQL proxy port (5434) typically cannot be exposed via standard HTTP I
 apiVersion: v1
 kind: Service
 metadata:
-  name: dbbat-postgres
+  name: dbbat-proxies
   namespace: dbbat
   labels:
     app: dbbat
@@ -303,6 +336,12 @@ spec:
   - name: postgres
     port: 5434
     targetPort: postgres
+  - name: oracle
+    port: 1522
+    targetPort: oracle
+  - name: mysql
+    port: 3307
+    targetPort: mysql
   type: LoadBalancer
 ```
 
@@ -313,7 +352,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: dbbat-postgres
+  name: dbbat-proxies
   namespace: dbbat
 spec:
   selector:
@@ -322,7 +361,15 @@ spec:
   - name: postgres
     port: 5434
     targetPort: postgres
-    nodePort: 30434  # Access via any node IP:30434
+    nodePort: 30434
+  - name: oracle
+    port: 1522
+    targetPort: oracle
+    nodePort: 31522
+  - name: mysql
+    port: 3307
+    targetPort: mysql
+    nodePort: 33307
   type: NodePort
 ```
 
@@ -339,6 +386,8 @@ metadata:
   namespace: ingress-nginx
 data:
   "5434": "dbbat/dbbat:5434"
+  "1522": "dbbat/dbbat:1522"
+  "3307": "dbbat/dbbat:3307"
 ```
 
 ## Complete Deployment
@@ -364,8 +413,8 @@ kubectl get ingress -n dbbat
 kubectl logs -n dbbat -l app=dbbat
 
 # Test health endpoint
-kubectl port-forward -n dbbat svc/dbbat 8080:8080
-curl http://localhost:8080/api/v1/health
+kubectl port-forward -n dbbat svc/dbbat 4200:4200
+curl http://localhost:4200/api/v1/health
 ```
 
 ## High Availability Considerations
@@ -382,7 +431,7 @@ For production deployments:
 metadata:
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
+    prometheus.io/port: "4200"
     prometheus.io/path: "/api/v1/health"
 ```
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -4,76 +4,111 @@ sidebar_position: 1
 
 # Introduction to DBBat
 
-DBBat is a transparent PostgreSQL proxy designed for query observability, access control, and safety. 
+DBBat is a transparent database proxy designed for query observability, access control, and safety.
 
-It allows to give temporary access to production databases for support, debugging and/or data analysis.
+It gives temporary, audited access to production databases for support, debugging, and data analysis — without handing out raw credentials.
 
-It can be used with a standard SQL client like psql, DBeave, pgAdmin, or even the standard app 
-(though it's not recommended in production).
+It speaks **PostgreSQL**, **Oracle**, and **MySQL/MariaDB** wire protocols, so any standard SQL client (psql, sqlplus, mysql, DBeaver, IntelliJ, pgAdmin, your application's ORM, …) can connect through DBBat without modification.
 
 ## Why DBBat?
 
 Giving access to production databases can be dangerous. DBBat provides:
-- **Query visibility**: Know what queries are being executed, how long they take, and what data they return
-- **Access control**: Grant temporary, limited access to databases for support, debugging, or data analysis
-- **Audit trails**: Maintain a complete record of who accessed what data and when
-- **Safety**: Prevent accidental writes to production databases
+- **Query visibility**: every query is logged with its SQL text, parameters, duration, and rows affected
+- **Result capture (optional)**: actual result rows can be stored alongside the query for replay/audit
+- **Access control**: time-windowed grants with fine-grained controls for read-only, blocking COPY, blocking DDL
+- **Audit trails**: append-only record of who did what — both inside the proxy and against the configuration API
+- **Safety**: defense in depth against accidental writes, file-system-touching SQL, and protocol-level data exfiltration
 
 DBBat addresses all these needs without requiring changes to your application code.
 
+## Supported Databases
+
+| Engine | Protocol | Default proxy port | Notes |
+|--------|----------|--------------------|-------|
+| PostgreSQL | PostgreSQL wire (`pgx/v5`) | `:5434` | First-class — auth terminated at the proxy, MD5/SCRAM clients work |
+| Oracle | TNS / TTC | `:1522` | O5LOGON proxy auth, hand-rolled TTC parser. End-to-end with `go-ora`; other clients reach AUTH but do not yet execute queries |
+| MySQL | MySQL wire (`go-mysql-org/go-mysql`) | `:3307` | `caching_sha2_password` (default), `mysql_clear_password`. TLS terminated at the proxy. `mysql_native_password` not supported |
+| MariaDB | MySQL wire (same listener) | `:3307` | Same as MySQL — `STMT_BULK_EXECUTE` refused (clients need batch-rewriting off) |
+
+Each engine has its own listener and is enabled independently via `DBB_LISTEN_PG` / `DBB_LISTEN_ORA` / `DBB_LISTEN_MYSQL`. Setting the variable to an empty string disables that proxy.
+
+For protocol-level details, see:
+- [Oracle proxy notes (TNS/TTC)](https://github.com/fclairamb/dbbat/blob/main/docs/oracle.md)
+- [MySQL proxy notes](https://github.com/fclairamb/dbbat/blob/main/docs/mysql.md)
+- [Dump file format](https://github.com/fclairamb/dbbat/blob/main/docs/dump-format.md)
+
 ## Core Features
 
-### Transparent Proxy
+### Transparent Multi-Protocol Proxy
 
-DBBat speaks the native PostgreSQL wire protocol. Any PostgreSQL client (psql, pgAdmin, your application's ORM) can connect through DBBat without modification.
+DBBat speaks each engine's native wire protocol. The same auth + grant + query-logging pipeline runs across all three.
 
 ```
-Client → DBBat (auth + grant check) → Target PostgreSQL
+psql / pg client     ─►  DBBat (auth + grant check + log) ─► PostgreSQL upstream
+sqlplus / go-ora     ─►  DBBat (TNS service-name routing)  ─► Oracle upstream
+mysql / mariadb cli  ─►  DBBat (caching_sha2_password)     ─► MySQL / MariaDB upstream
 ```
 
 ### User Management
 
-- Users authenticate to DBBat with their own credentials
-- Admin users can create/modify other users and manage all resources
-- User credentials are separate from target database credentials
+- Users authenticate to DBBat with their own credentials (Argon2id-hashed passwords)
+- Roles: `admin`, `viewer`, `connector` — combinable, additive
+- Optional Slack OAuth for sign-in, with auto-provisioning configurable per default-role
+- API keys (`dbb_…`) for programmatic access; intentionally cannot create or revoke other keys
 
 ### Database Configuration
 
-- Store multiple target database connection details
-- Credentials encrypted at rest with AES-256-GCM
-- Map DBBat database names to target PostgreSQL servers
+- Store multiple target database connection details — one entry per database
+- Credentials encrypted at rest with AES-256-GCM (AAD-bound to the database UID, so a stolen ciphertext cannot be transplanted)
+- A `protocol` field marks each entry as `postgresql`, `oracle`, `mysql`, or `mariadb`
+- For Oracle, an `oracle_service_name` is stored alongside the database name
 
 ### Connection & Query Tracking
 
-- Track all connections with user, timestamp, source IP, and target database
-- Log all queries with SQL text, execution time, and rows affected
-- Optionally store query result data for audit/replay
+- Track all connections with user, source IP, target database, timestamps, query count, and bytes transferred
+- Log every query with SQL text, parameters, duration, rows affected, and any error
+- Optional result-row capture, bounded by `max_result_rows` and `max_result_bytes`
+- For MySQL, both text protocol (`COM_QUERY`) and binary protocol (`COM_STMT_EXECUTE`) are decoded and logged
 
 ### Access Control
 
-- Grant time-windowed access (starts_at, expires_at) to specific databases
-- Access levels: `read` or `write`
-- Optional quotas: max queries, max bytes transferred
-- Automatic expiration or manual revocation
-- Full audit log of all access control changes
+- Grant time-windowed access (`starts_at`, `expires_at`) to specific databases
+- Apply any combination of controls:
+  - `read_only`: regex SQL inspection + PostgreSQL `default_transaction_read_only` + MySQL/MariaDB write blocks
+  - `block_copy`: forbid `COPY` (PostgreSQL) and `LOAD DATA` / `SELECT … INTO OUTFILE` (MySQL)
+  - `block_ddl`: forbid `CREATE`, `ALTER`, `DROP`, `TRUNCATE`
+- Optional quotas: `max_query_counts`, `max_bytes_transferred`
+- Automatic expiration or manual revocation, with audit log entries for every change
+
+### Session Packet Dumps
+
+Optional per-session binary dumps of the post-auth command stream, written as `.dbbat-dump` files. Same format across all protocols (see [the dump-format spec](https://github.com/fclairamb/dbbat/blob/main/docs/dump-format.md)). Use `dbbat dump anonymise <input>` to strip session metadata before sharing a capture.
+
+### REST API + Web UI
+
+- Full OpenAPI 3.0 specification, served at `/api/openapi.yml`
+- Swagger UI at `/api/docs`
+- Embedded React frontend at `/app` for grant/user/database management and query browsing
+- All API endpoints versioned under `/api/v1/`
 
 ## How It Works
 
 Everything described here can be done via the REST API or the web UI.
 
 1. **Admin creates a user**
-2. **Admin configures a target database** (host, port, credentials)
-3. **Admin grants the user access** to the database with time window and optional quotas
-4. **User connects** with psql or any PostgreSQL client using their DBBat credentials
-5. **DBBat authenticates** the user and checks for valid grants
+2. **Admin configures a target database** (protocol, host, port, credentials, optional `oracle_service_name`)
+3. **Admin grants the user access** to the database with a time window, controls, and optional quotas
+4. **User connects** with `psql` / `sqlplus` / `mysql` / any client, using their DBBat credentials (or an API key)
+5. **DBBat authenticates** the user, checks for a valid grant, and connects to the upstream using the stored encrypted credentials
 6. **DBBat proxies** all queries to the target database, logging everything
 
 ## Security
 
-- **User passwords**: Hashed with Argon2id
-- **Database credentials**: Encrypted with AES-256-GCM
-- **Encryption key**: From environment variable or key file
-- **Default admin**: Created on first startup (username: `admin`, password: `admin`)
+- **User passwords**: Argon2id (configurable preset and parameters)
+- **Database credentials**: AES-256-GCM, AAD-bound to the database UID
+- **API keys**: encrypted blobs, scoped restrictions (no key-management via key)
+- **Encryption key**: from `DBB_KEY` (base64) or `DBB_KEYFILE`; auto-generated at `~/.dbbat/key` on first start if neither is set
+- **Default admin**: created on first startup (username: `admin`, password: `admin`) — must be changed before login
 
 ## Try the Demo
 

--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -109,7 +109,7 @@ Grants control which users can connect to which databases through the proxy.
 | `expires_at` | Grant automatically expires after this time |
 | `max_query_counts` | Maximum queries allowed (quota) |
 | `max_bytes_transferred` | Maximum data transfer allowed (quota) |
-| `access_level` | `read` or `write` |
+| `controls` | Combination of `read_only`, `block_copy`, `block_ddl`. Empty = full write access. |
 
 **Recommendation**: Always set all constraints. Time-limited grants with quotas minimize blast radius if credentials are compromised.
 
@@ -124,28 +124,32 @@ Grants control which users can connect to which databases through the proxy.
 
 ## Read-Only Mode
 
-When a grant has `access_level: read`, DBBat enforces read-only access through **defense in depth**.
+When a grant has `read_only` in its `controls`, DBBat enforces read-only access through **defense in depth**.
 
-### Layer 1: Query Inspection
+### Layer 1: Query Inspection (all engines)
 
 Queries are inspected and blocked if they match write patterns:
 
-- **DML**: `INSERT`, `UPDATE`, `DELETE`, `MERGE`
+- **DML**: `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `REPLACE`
 - **DDL**: `CREATE`, `ALTER`, `DROP`, `TRUNCATE`
 - **DCL**: `GRANT`, `REVOKE`
-- **Other**: `COPY FROM`, `CALL` (procedures)
+- **Other**: `COPY FROM` (PG), `CALL` (procedures), `LOAD DATA`, `SELECT … INTO OUTFILE`, `SELECT … INTO DUMPFILE` (MySQL)
 
-### Layer 2: PostgreSQL Session Setting
+### Layer 2: Engine-level session flag
 
-At connection establishment, DBBat sets:
+- **PostgreSQL** — at connection establishment, DBBat sets:
 
-```sql
-SET SESSION default_transaction_read_only = on;
-```
+  ```sql
+  SET SESSION default_transaction_read_only = on;
+  ```
 
-PostgreSQL itself then blocks any write operation, regardless of SQL syntax.
+  PostgreSQL then blocks any write regardless of SQL syntax.
 
-### Layer 3: Bypass Prevention
+- **MySQL/MariaDB** — `SET SESSION TRANSACTION READ ONLY` only applies to the *next* transaction and is trivially bypassable, so DBBat does **not** rely on it. Layer 1 (regex inspection) is the active control. **Recommendation**: also `GRANT SELECT` only to the upstream MySQL user.
+
+- **Oracle** — same as MySQL: regex inspection only. The defensive recommendation is to grant `CREATE SESSION` + `SELECT` privileges to the upstream Oracle user, nothing more.
+
+### Layer 3: Bypass Prevention (PostgreSQL)
 
 Attempts to disable read-only mode are blocked:
 
@@ -159,10 +163,17 @@ Attempts to disable read-only mode are blocked:
 Read-only mode is **defense in depth for trusted users**, not a security boundary against malicious actors:
 
 - Regex-based inspection may miss edge cases
-- New PostgreSQL syntax could bypass detection
+- New SQL syntax could bypass detection
 - Functions with `SECURITY DEFINER` might execute writes
 
-**For untrusted access**: Create a dedicated PostgreSQL user with `GRANT SELECT` only.
+**For untrusted access**: also restrict the upstream database user to read-only privileges.
+
+## MySQL `LOCAL INFILE` Defense
+
+`LOAD DATA LOCAL INFILE` lets a MySQL server *ask* a connected client to upload an arbitrary local file. A compromised upstream server could issue this request mid-query against any client. DBBat blocks it on two layers:
+
+1. **SQL regex** refuses the keyword in inbound client queries.
+2. **Capability opt-out**: when the proxy connects upstream it explicitly clears `CLIENT_LOCAL_FILES` from the negotiated capabilities. The upstream then never advertises the feature on this connection, so even a compromised server cannot request a `LOCAL INFILE` upload through the proxy.
 
 ## Audit Trail
 
@@ -209,10 +220,9 @@ DBBat supports PostgreSQL SSL modes for upstream connections:
 
 ### Client Connections
 
-DBBat accepts plain PostgreSQL protocol connections. For encryption:
-
-- Deploy behind a TLS-terminating load balancer, or
-- Use network-level encryption (VPN, private network)
+- **PostgreSQL listener**: plain protocol only. Deploy behind a TLS-terminating load balancer, a VPN, or a private network.
+- **Oracle listener**: plain TNS only. Same recommendation.
+- **MySQL listener**: TLS termination is built in. Configure `DBB_MYSQL_TLS_CERT_FILE` / `DBB_MYSQL_TLS_KEY_FILE` (PEM-encoded) for production. If unset, the proxy auto-generates a self-signed cert and an RSA-2048 keypair at startup — fine for development, not for production. `DBB_MYSQL_TLS_DISABLE=true` refuses TLS and stays plaintext-only.
 
 ## Security Checklist
 
@@ -228,14 +238,17 @@ DBBat accepts plain PostgreSQL protocol connections. For encryption:
 
 - [ ] Use time-limited grants (hours/days, not years)
 - [ ] Set query and byte quotas on all grants
-- [ ] Prefer `read` access level unless writes are required
+- [ ] Prefer `read_only` (and `block_ddl` / `block_copy` where useful) unless writes are required
 - [ ] Review audit logs regularly
 - [ ] Rotate API keys periodically
 - [ ] Monitor for blocked query attempts
 
 ### For Target Databases
 
-- [ ] Use dedicated PostgreSQL user for DBBat upstream connections
+- [ ] Use a dedicated upstream user for each target (PostgreSQL, Oracle, MySQL/MariaDB)
 - [ ] Grant minimum required privileges to that user
-- [ ] For read-only grants, use PostgreSQL user with only SELECT privileges
-- [ ] Enable PostgreSQL logging as additional audit layer
+- [ ] For read-only grants, also restrict the upstream user to read-only privileges
+  - PostgreSQL: `GRANT SELECT` only
+  - MySQL/MariaDB: `GRANT SELECT ON db.* TO 'dbbat_ro'@'%'`
+  - Oracle: `CREATE SESSION` + `SELECT` privileges only
+- [ ] Enable engine-level audit logging as an additional layer

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from "@docusaurus/preset-classic";
 const config: Config = {
   title: "DBBat",
   tagline:
-    "Give (temporary) accesses to prod databases. Every query logged. Every data saved.",
+    "Give (temporary) access to your PostgreSQL, Oracle, MySQL & MariaDB databases. Every query logged. Every result captured.",
   favicon: "img/favicon.ico",
 
   url: "https://dbbat.com",

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -10,13 +10,13 @@ type FeatureItem = {
 
 const FeatureList: FeatureItem[] = [
   {
-    title: "Transparent Proxy",
+    title: "Multi-Engine Proxy",
     emoji: "🔌",
     description: (
       <>
-        Connect any PostgreSQL client through DBBat without code changes.
-        Standard PostgreSQL wire protocol support means zero application
-        modifications required.
+        PostgreSQL, Oracle, and MySQL/MariaDB on independent listeners. Connect
+        any standard client — psql, sqlplus, mysql, DBeaver, your ORM — without
+        application changes.
       </>
     ),
   },
@@ -25,30 +25,31 @@ const FeatureList: FeatureItem[] = [
     emoji: "🔍",
     description: (
       <>
-        Track every query with full SQL text, execution time, rows affected, and
-        optional result data capture. Gain complete visibility into database
-        activity.
+        Track every query with full SQL text, parameters, execution time, rows
+        affected, and optional result-data capture. Text and binary protocols
+        decoded the same way.
       </>
     ),
   },
   {
-    title: "Access Control",
+    title: "Granular Access Control",
     emoji: "🔐",
     description: (
       <>
-        Grant time-windowed access with read/write permissions. Set quotas on
-        queries and data transfer. Automatically expire or manually revoke
-        access.
+        Time-windowed grants with combinable controls — <code>read_only</code>,{" "}
+        <code>block_copy</code>, <code>block_ddl</code> — plus per-grant quotas
+        on queries and bytes transferred.
       </>
     ),
   },
   {
-    title: "User Management",
+    title: "User & API Key Management",
     emoji: "👥",
     description: (
       <>
-        Create users with their own credentials separate from database
-        credentials. Admin users can manage all resources and grants.
+        Local users with <code>admin</code>, <code>viewer</code>, and{" "}
+        <code>connector</code> roles. Optional Slack sign-in. API keys for
+        programmatic access — and they cannot create or revoke other keys.
       </>
     ),
   },
@@ -58,17 +59,51 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
         Passwords hashed with Argon2id, database credentials encrypted with
-        AES-256-GCM. Full audit logging of all access control changes.
+        AES-256-GCM and bound to the database UID. Append-only audit log of
+        every administrative change.
       </>
     ),
   },
   {
-    title: "REST API",
+    title: "Defense in Depth",
+    emoji: "🧱",
+    description: (
+      <>
+        Read-only enforced via SQL inspection <em>and</em> engine-level session
+        flags. MySQL <code>LOCAL INFILE</code> opted out of the upstream
+        capabilities. PostgreSQL session bypass attempts blocked.
+      </>
+    ),
+  },
+  {
+    title: "Session Packet Dumps",
+    emoji: "📼",
+    description: (
+      <>
+        Optional per-session binary capture of the post-auth command stream.
+        Same <code>.dbbat-dump</code> format across all protocols, with a CLI
+        anonymiser for safe sharing.
+      </>
+    ),
+  },
+  {
+    title: "REST API + Web UI",
     emoji: "🌐",
     description: (
       <>
-        Full-featured REST API with OpenAPI documentation. Manage users,
-        databases, grants, and view connections and queries programmatically.
+        Full OpenAPI 3.0 spec served at <code>/api/docs</code>. React frontend
+        embedded in the binary at <code>/app</code> for managing users,
+        databases, grants, and browsing query history.
+      </>
+    ),
+  },
+  {
+    title: "Single Binary",
+    emoji: "📦",
+    description: (
+      <>
+        One Go binary backed by PostgreSQL. Distroless Docker image, Helm chart,
+        Kubernetes-friendly. Stateless beyond its store — replicas welcome.
       </>
     ),
   },

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -93,16 +93,24 @@ function QuickStart() {
     <section className={styles.quickStart}>
       <div className="container">
         <Heading as="h2">Quick Start</Heading>
-        <p>Get DBBat running in seconds with Docker:</p>
+        <p>
+          Get DBBat running in seconds with Docker — one container fronts
+          PostgreSQL, Oracle, and MySQL/MariaDB:
+        </p>
         <pre className={styles.codeBlock}>
           <code>
             docker run
             <br />
-            &nbsp;&nbsp;-p 5432:5432
+            &nbsp;&nbsp;-p 5434:5434&nbsp;&nbsp;# PostgreSQL proxy
             <br />
-            &nbsp;&nbsp;-p 8080:8080
+            &nbsp;&nbsp;-p 1522:1522&nbsp;&nbsp;# Oracle proxy
             <br />
-            &nbsp;&nbsp;-e DBB_DSN=postgres://dbbat:dbbat@pgserver:5432/dbbat
+            &nbsp;&nbsp;-p 3307:3307&nbsp;&nbsp;# MySQL / MariaDB proxy
+            <br />
+            &nbsp;&nbsp;-p 4200:4200&nbsp;&nbsp;# REST API + web UI
+            <br />
+            &nbsp;&nbsp;-e
+            DBB_DSN=postgres://dbbat:dbbat@pgserver:5432/dbbat
             <br />
             &nbsp;&nbsp;ghcr.io/fclairamb/dbbat
           </code>
@@ -121,8 +129,8 @@ export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title} - PostgreSQL Observability Proxy`}
-      description="Give your devs access to prod. A PostgreSQL proxy with full query logging and access control."
+      title={`${siteConfig.title} - Database Observability Proxy`}
+      description="Give your devs (temporary) access to prod. PostgreSQL, Oracle, and MySQL/MariaDB proxy with full query logging, fine-grained access control, and session capture."
     >
       <HomepageHeader />
       <main>


### PR DESCRIPTION
## Summary

- Refresh every user-facing doc surface (README, repo CLAUDE.md, dbbat.com Docusaurus site) to reflect that DBBat is now a multi-engine proxy — PostgreSQL, Oracle, and MySQL/MariaDB — not PostgreSQL-only.
- Replace the obsolete grant API (`access_level: read/write`, `max_queries`/`max_bytes`) with the real `controls` array (`read_only`, `block_copy`, `block_ddl`) and the real quota fields (`max_query_counts`, `max_bytes_transferred`).
- Fix the API port everywhere (`:4200`, not `:8080`) and document the Oracle (`1522`) and MySQL (`3307`) listener ports.

## Highlights

- New `website/docs/features/supported-databases.md` — full per-engine matrix with status and limitations (including the Oracle client-compatibility table and the MySQL/MariaDB blocked-operations list).
- New `website/docs/features/session-dumps.md` — `DBB_DUMP_*` configuration, the binary `.dbbat-dump` format, and `dbbat dump anonymise`.
- Rewrote `intro.md`, `configuration/index.md`, `configuration/databases.md`, `features/access-control.md`, `features/query-logging.md`, `features/user-management.md`, and `api/index.md` against the real code (`main.go`, `internal/config/config.go`, `internal/api/openapi.yml`).
- Updated `security.md` with multi-engine read-only enforcement, MySQL `LOCAL INFILE` defense, MySQL listener TLS, and per-engine privilege recommendations.
- Updated all install pages (Docker, Compose, Binary, Kubernetes) to expose the Oracle/MySQL ports and use the correct API port for probes/Prometheus annotations.
- Refreshed homepage tagline, hero copy, Quick Start snippet, and feature cards in `website/src/`.

## Test plan
- [x] `bun install` + `bun run build` in `website/` — site builds cleanly with no broken links and no MDX errors.
- [x] No Go code touched; only Markdown/MDX/TSX text changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)