### PR TITLE
ci: skip build jobs on release-please-* PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   # ===========================================================================
   lint:
     runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please-')
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -35,6 +36,7 @@ jobs:
   # ===========================================================================
   frontend:
     runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please-')
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -77,6 +79,7 @@ jobs:
   # ===========================================================================
   test:
     runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please-')
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -99,6 +102,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     needs: [frontend]
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please-')
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -137,6 +141,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-24.04
     needs: [build]
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please-')
     steps:
       - uses: actions/checkout@v6.0.2
 


### PR DESCRIPTION
## Summary
- Skip lint, frontend, test, build, and e2e-tests jobs on PRs whose head branch starts with \`release-please-\`
- Tag/main pushes are unaffected — only \`pull_request\` events get the skip

Release-please PRs only update CHANGELOG and version files, so running the full pipeline on them just burns CI time.

## Test plan
- [ ] Verify all build/lint/test jobs are skipped on this PR (branch starts with \`release-please-\`)
- [ ] Verify a normal PR (non release-please branch) still runs all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)