### PR TITLE
fix(oracle): unbreak upstream auth parser; patch AUTH_SVR_RESPONSE for python-oracledb / SQLcl

### DIFF
--- a/internal/proxy/oracle/auth_svr_response.go
+++ b/internal/proxy/oracle/auth_svr_response.go
@@ -1,0 +1,148 @@
+package oracle
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// authSvrResponsePlaintextLen is the length of the AUTH_SVR_RESPONSE plaintext
+// the client expects: 16 random prefix bytes followed by the literal ASCII
+// marker "SERVER_TO_CLIENT".
+const authSvrResponsePlaintextLen = 32
+
+// authSvrResponseHexLen is the on-wire hex length of AUTH_SVR_RESPONSE — 96
+// characters encoding 48 bytes (3 AES blocks: 32-byte plaintext plus a full
+// PKCS#5 pad block).
+const authSvrResponseHexLen = 96
+
+// authSvrResponseMarker is the literal trailing plaintext the client checks
+// after AES decryption to confirm the proxy holds the negotiated session key.
+var authSvrResponseMarker = []byte("SERVER_TO_CLIENT")
+
+// authSvrResponseKey is the KV key the upstream's AUTH OK packet uses for
+// the encrypted server-to-client confirmation field.
+var authSvrResponseKey = []byte("AUTH_SVR_RESPONSE")
+
+// patchAuthSvrResponse rewrites the AUTH_SVR_RESPONSE field inside an Oracle
+// AUTH OK packet so its ciphertext decrypts under the supplied key. Both
+// modern Oracle clients (python-oracledb thin, JDBC thin / SQLcl) verify
+// AUTH_SVR_RESPONSE against the O5LOGON combined key they negotiated with the
+// proxy; without this patch they reject the AUTH OK with DPY-4035 / ORA-17401
+// because the upstream's value is encrypted with the proxy's combined key
+// against the upstream, not the client's.
+//
+// The packet layout (post-flag bytes) for that field is:
+//
+//	[01 11 11] AUTH_SVR_RESPONSE(17B) [01 60 60] <96 hex chars> 00
+//
+// The hex value is replaced in place; surrounding bytes (key, length
+// prefixes, KV flag) are preserved. Returns a fresh slice.
+func patchAuthSvrResponse(authOK []byte, combinedKey []byte) ([]byte, error) {
+	if len(authOK) == 0 {
+		return nil, ErrAuthSvrResponseKeyNotFound
+	}
+
+	keyIdx := bytes.Index(authOK, authSvrResponseKey)
+	if keyIdx < 0 {
+		return nil, ErrAuthSvrResponseKeyNotFound
+	}
+
+	hexStart, err := findAuthSvrResponseHexStart(authOK, keyIdx+len(authSvrResponseKey))
+	if err != nil {
+		return nil, err
+	}
+
+	if hexStart+authSvrResponseHexLen > len(authOK) {
+		return nil, ErrAuthSvrResponseTruncated
+	}
+
+	freshHex, err := buildAuthSvrResponseValue(combinedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(freshHex) != authSvrResponseHexLen {
+		return nil, fmt.Errorf("%w: got %d, want %d", ErrAuthSvrResponseBadLength, len(freshHex), authSvrResponseHexLen)
+	}
+
+	out := make([]byte, len(authOK))
+	copy(out, authOK)
+	copy(out[hexStart:hexStart+authSvrResponseHexLen], freshHex)
+
+	return out, nil
+}
+
+// findAuthSvrResponseHexStart locates the first byte of the 96-character hex
+// value following the AUTH_SVR_RESPONSE key. The wire format encodes the
+// preceding length tag using a TTC compressed integer (`01 60 60`), so we
+// scan from `after` until we find a run of 96 uppercase-hex bytes.
+func findAuthSvrResponseHexStart(authOK []byte, after int) (int, error) {
+	for i := after; i+authSvrResponseHexLen <= len(authOK); i++ {
+		if isHexRun(authOK, i, authSvrResponseHexLen) {
+			return i, nil
+		}
+	}
+
+	return 0, fmt.Errorf("%w: no %d-char hex run found near AUTH_SVR_RESPONSE", ErrAuthSvrResponseNotHex, authSvrResponseHexLen)
+}
+
+// isHexRun reports whether buf[start:start+length] is composed entirely of
+// uppercase hex bytes (0-9, A-F).
+func isHexRun(buf []byte, start, length int) bool {
+	if start+length > len(buf) {
+		return false
+	}
+
+	for i := start; i < start+length; i++ {
+		c := buf[i]
+		if (c < '0' || c > '9') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+
+	return true
+}
+
+// buildAuthSvrResponseValue computes a fresh AUTH_SVR_RESPONSE hex string
+// encrypted under the supplied combined key. The plaintext is 16 random
+// prefix bytes followed by the ASCII marker "SERVER_TO_CLIENT"; AES-CBC
+// with a zero IV and PKCS#5 padding produces 48 bytes of ciphertext, hex
+// encoded as 96 uppercase characters.
+func buildAuthSvrResponseValue(combinedKey []byte) ([]byte, error) {
+	plaintext := make([]byte, authSvrResponsePlaintextLen)
+	if _, err := rand.Read(plaintext[:16]); err != nil {
+		return nil, fmt.Errorf("rand AUTH_SVR_RESPONSE prefix: %w", err)
+	}
+
+	copy(plaintext[16:], authSvrResponseMarker)
+
+	blk, err := aes.NewCipher(combinedKey)
+	if err != nil {
+		return nil, fmt.Errorf("aes new cipher: %w", err)
+	}
+
+	padded := pkcs5Pad(plaintext, blk.BlockSize())
+
+	enc := cipher.NewCBCEncrypter(blk, make([]byte, blk.BlockSize()))
+
+	out := make([]byte, len(padded))
+	enc.CryptBlocks(out, padded)
+
+	hexed := strings.ToUpper(hex.EncodeToString(out))
+
+	return []byte(hexed), nil
+}
+
+// AUTH_SVR_RESPONSE patcher errors.
+var (
+	ErrAuthSvrResponseKeyNotFound = errors.New("AUTH_SVR_RESPONSE key not found in AUTH OK")
+	ErrAuthSvrResponseTruncated   = errors.New("AUTH_SVR_RESPONSE value truncated")
+	ErrAuthSvrResponseNotHex      = errors.New("AUTH_SVR_RESPONSE value not uppercase hex")
+	ErrAuthSvrResponseBadLength   = errors.New("AUTH_SVR_RESPONSE rebuilt with wrong length")
+)

--- a/internal/proxy/oracle/o5logon.go
+++ b/internal/proxy/oracle/o5logon.go
@@ -27,6 +27,11 @@ type O5LogonServer struct {
 	salt             []byte // 10-byte salt (from stored verifier)
 	verifierKey      []byte // 24-byte key derived from password+salt
 	serverSessionKey []byte // 48-byte random (generated per auth)
+
+	// CombinedKey is set by DecryptPassword to MD5(serverSessKey || clientSessKey)
+	// derived from both session keys after a successful Phase 2. It is the AES key
+	// the client expects for AUTH_SVR_RESPONSE in the AUTH OK forwarded back.
+	CombinedKey []byte
 }
 
 // GenerateO5LogonVerifier creates salt + verifier key from a plaintext password.
@@ -80,6 +85,10 @@ func (s *O5LogonServer) GenerateChallenge() (string, string, error) {
 // DecryptPassword extracts the plaintext password from the client's AUTH Phase 2.
 // The client encrypts: random_prefix(16 bytes) + password using AES-192-CBC
 // with a key derived from MD5(server_session_key || client_session_key).
+//
+// Side-effect: on success, the negotiated combined key is stored on the
+// receiver as CombinedKey so callers can reuse it (e.g. to encrypt
+// AUTH_SVR_RESPONSE in the AUTH OK payload forwarded to the client).
 func (s *O5LogonServer) DecryptPassword(encClientSessKey, encPassword string) (string, error) {
 	// Decode client session key
 	encClientSessKeyBytes, err := hex.DecodeString(encClientSessKey)
@@ -97,6 +106,7 @@ func (s *O5LogonServer) DecryptPassword(encClientSessKey, encPassword string) (s
 
 	// Derive combined key from both session keys
 	combinedKey := deriveCombinedKey(s.serverSessionKey, clientSessionKey)
+	s.CombinedKey = combinedKey
 
 	// Decode and decrypt the password
 	encPasswordBytes, err := hex.DecodeString(encPassword)

--- a/internal/proxy/oracle/session.go
+++ b/internal/proxy/oracle/session.go
@@ -45,6 +45,18 @@ type session struct {
 	// PBKDF2 path.
 	upstreamCustomHash bool
 
+	// clientCombinedKey is the AES key derived from the dbbat-as-server O5LOGON
+	// session keys (MD5(serverSessKey || clientSessKey)). Captured by
+	// authenticateClient on success so the AUTH OK forwarded back to the client
+	// can carry an AUTH_SVR_RESPONSE encrypted with the same key the client
+	// expects. Empty when the client used the empty-AUTH_PASSWORD path.
+	clientCombinedKey []byte
+
+	// upstreamAuthOKResponse is the raw upstream Phase 2 response packet
+	// (TNS framing included) captured during runUpstreamClientAuth. Used as the
+	// AUTH OK forwarded to the client after AUTH_SVR_RESPONSE patching.
+	upstreamAuthOKResponse []byte
+
 	// Query tracking
 	tracker      *oracleQueryTracker
 	queryStorage config.QueryStorageConfig
@@ -134,10 +146,29 @@ func (s *session) run() error {
 		return fmt.Errorf("upstream auth failed: %w", err)
 	}
 
-	// Step 6b: Send the full AUTH OK + session properties response to client.
-	// This is a captured response from Oracle 19c that includes AUTH_VERSION_STRING,
-	// session properties, and the code-4 end marker that go-ora expects.
-	if _, err := s.clientConn.Write(capturedAuthOKResponse); err != nil {
+	// Step 6b: Forward the upstream's real AUTH OK packet to the client, with
+	// AUTH_SVR_RESPONSE re-encrypted under the client's O5LOGON combined key.
+	// Without that patch, modern clients (python-oracledb thin → DPY-4035,
+	// JDBC thin / SQLcl → ORA-17401) reject the AUTH OK because the upstream
+	// encrypted that field with its own combined key. go-ora ignores the
+	// field, so the previous static-captured-response path worked for it
+	// while silently breaking everyone else.
+	authOK := s.upstreamAuthOKResponse
+	if authOK == nil {
+		authOK = capturedAuthOKResponse
+	}
+
+	if len(s.clientCombinedKey) > 0 && len(s.upstreamAuthOKResponse) > 0 {
+		patched, err := patchAuthSvrResponse(authOK, s.clientCombinedKey)
+		if err != nil {
+			s.logger.WarnContext(s.ctx, "failed to patch AUTH_SVR_RESPONSE; forwarding upstream packet unchanged",
+				slog.Any("error", err))
+		} else {
+			authOK = patched
+		}
+	}
+
+	if _, err := s.clientConn.Write(authOK); err != nil {
 		return fmt.Errorf("failed to send AUTH OK: %w", err)
 	}
 
@@ -456,6 +487,8 @@ func (s *session) authenticateClient(phase1Pkt *TNSPacket) error {
 	if apiKey.UserID != user.UID {
 		return ErrAPIKeyOwnerMismatchOracle
 	}
+
+	s.clientCombinedKey = o5.CombinedKey
 
 	// Increment usage asynchronously
 	go func() { _ = s.store.IncrementAPIKeyUsage(context.Background(), apiKey.ID) }()

--- a/internal/proxy/oracle/upstream_auth_client.go
+++ b/internal/proxy/oracle/upstream_auth_client.go
@@ -1,7 +1,6 @@
 package oracle
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -74,7 +73,7 @@ func (s *session) runUpstreamClientAuth() error {
 		return fmt.Errorf("write upstream AUTH Phase 1: %w", err)
 	}
 
-	authResp, err := s.readUpstreamAuthMessages()
+	authResp, _, err := s.readUpstreamAuthMessages()
 	if err != nil {
 		return fmt.Errorf("read upstream AUTH Phase 1 response: %w", err)
 	}
@@ -97,7 +96,7 @@ func (s *session) runUpstreamClientAuth() error {
 		return fmt.Errorf("write upstream AUTH Phase 2: %w", err)
 	}
 
-	finalResp, err := s.readUpstreamAuthMessages()
+	finalResp, finalRaw, err := s.readUpstreamAuthMessages()
 	if err != nil {
 		return fmt.Errorf("read upstream AUTH Phase 2 response: %w", err)
 	}
@@ -105,6 +104,8 @@ func (s *session) runUpstreamClientAuth() error {
 	if finalResp.OracleErr != 0 {
 		return fmt.Errorf("%w: ORA-%05d %s", ErrUpstreamAuthPhase2Rejected, finalResp.OracleErr, finalResp.OracleErrText)
 	}
+
+	s.upstreamAuthOKResponse = finalRaw
 
 	s.logger.InfoContext(s.ctx, "upstream Oracle AUTH complete on relay-phase socket",
 		slog.String("user", s.database.Username),
@@ -122,6 +123,10 @@ func (s *session) writeUpstreamData(body []byte) error {
 	payload = append(payload, body...)
 
 	pkt := encodeV315DataPacket(payload)
+
+	s.logger.DebugContext(s.ctx, "upstream AUTH: writing packet",
+		slog.Int("pkt_len", len(pkt)),
+		slog.Int("body_len", len(body)))
 
 	if _, err := s.upstreamConn.Write(pkt); err != nil {
 		return fmt.Errorf("upstream write: %w", err)
@@ -147,16 +152,28 @@ type upstreamAuthResponse struct {
 // readUpstreamAuthMessages reads TNS Data packets from upstream until an
 // end-of-call message code (4 or 9) appears. Multiple Data packets may
 // carry pieces of the same TTC stream.
-func (s *session) readUpstreamAuthMessages() (*upstreamAuthResponse, error) {
+//
+// The last raw Data packet read is returned alongside the parsed response.
+// Callers (notably runUpstreamClientAuth's Phase 2 read) reuse it as the
+// AUTH OK packet forwarded to the client after AUTH_SVR_RESPONSE patching.
+func (s *session) readUpstreamAuthMessages() (*upstreamAuthResponse, []byte, error) {
 	resp := &upstreamAuthResponse{properties: make(map[string]string)}
 
-	var buf []byte
+	var (
+		buf     []byte
+		lastRaw []byte
+	)
 
 	for {
 		pkt, err := readTNSPacket(s.upstreamConn)
 		if err != nil {
-			return nil, fmt.Errorf("read upstream packet: %w", err)
+			return nil, nil, fmt.Errorf("read upstream packet: %w", err)
 		}
+
+		s.logger.DebugContext(s.ctx, "upstream AUTH: received packet",
+			slog.String("type", pkt.Type.String()),
+			slog.Int("raw_len", len(pkt.Raw)),
+			slog.Int("payload_len", len(pkt.Payload)))
 
 		if pkt.Type != TNSPacketTypeData {
 			s.logger.DebugContext(s.ctx, "upstream AUTH: skipping non-Data packet",
@@ -170,22 +187,30 @@ func (s *session) readUpstreamAuthMessages() (*upstreamAuthResponse, error) {
 			continue
 		}
 
+		lastRaw = pkt.Raw
 		buf = append(buf, pkt.Payload[ttcDataFlagsSize:]...)
 
 		if parseAuthMessageStream(buf, resp) {
-			return resp, nil
+			return resp, lastRaw, nil
 		}
 	}
 }
 
-// parseAuthMessageStream walks a TTC byte stream and returns true when an
-// end-of-call message code (4 or 9) is observed.
+// parseAuthMessageStream walks a TTC byte stream and returns true when the
+// AUTH response is sufficiently complete: either after consuming a 0x08
+// dictionary (which carries the entire Phase 1 challenge or Phase 2 session
+// properties) or after seeing an explicit end-of-call code 0x04 / 0x09 with
+// an Oracle error.
 //
 // Codes:
 //
-//	0x08              dictionary (KV pairs)
-//	0x04 / 0x09       end-of-call (with a Summary structure)
-//	0x0F              warning (skipped)
+//	0x08              dictionary (KV pairs) — terminal: contains everything
+//	                  we need for Phase 1 (AUTH_SESSKEY + AUTH_VFR_DATA +
+//	                  AUTH_PBKDF2_*) or Phase 2 (AUTH_VERSION_STRING + ...).
+//	0x04 / 0x09       end-of-call (with a Summary structure). Auth flows use
+//	                  this only when the upstream rejects (no preceding 0x08)
+//	                  or as a trailing marker after a dict (already handled).
+//	0x0F              warning (6 bytes, skipped).
 //
 // The function is tolerant: when it cannot decode a region it returns false
 // so the caller reads more bytes.
@@ -198,12 +223,11 @@ func parseAuthMessageStream(buf []byte, resp *upstreamAuthResponse) bool {
 
 		switch msgCode {
 		case 0x08:
-			n, ok := parseAuthKVDictionary(buf[pos:], resp)
-			if !ok {
+			if _, ok := parseAuthKVDictionary(buf[pos:], resp); !ok {
 				return false
 			}
 
-			pos += n
+			return true
 
 		case 0x04, 0x09:
 			parseAuthSummary(buf[pos:], resp)
@@ -227,15 +251,17 @@ func parseAuthMessageStream(buf []byte, resp *upstreamAuthResponse) bool {
 
 // parseAuthKVDictionary parses a TTC AUTH KV dictionary that follows a 0x08
 // message code. Returns ok=false when the dictionary is truncated.
+//
+// The dictionary length is a TTC compressed integer, matching go-ora's
+// session.GetInt(2, bigEndian=true, compress=true). A 1-byte size prefix is
+// followed by `size` big-endian bytes encoding the count of KV pairs.
 func parseAuthKVDictionary(buf []byte, resp *upstreamAuthResponse) (int, bool) {
-	const dictLenSize = 2
-
-	if len(buf) < dictLenSize {
+	dictLen, n := readCompressedInt(buf)
+	if n == 0 {
 		return 0, false
 	}
 
-	dictLen := int(binary.BigEndian.Uint16(buf[:dictLenSize]))
-	pos := dictLenSize
+	pos := n
 
 	for i := 0; i < dictLen; i++ {
 		pair, ok := readAuthKVPair(buf[pos:])
@@ -336,25 +362,29 @@ func recordAuthProperty(key, value string, flag int, resp *upstreamAuthResponse)
 
 // parseAuthSummary walks the Summary structure that follows a code 4 / 9
 // message, extracting any embedded ORA-* error. Best-effort.
+//
+// The Summary's first compressed int is EndOfCallStatus (not the Oracle
+// error code). For Phase 1 challenge responses Oracle returns EndOfCallStatus
+// non-zero with RetCode=0, which is not an error. Only set OracleErr when an
+// "ORA-NNNNN" string is actually present in the buffer (matching go-ora's
+// HasError behavior).
 func parseAuthSummary(buf []byte, resp *upstreamAuthResponse) {
-	const minSummaryLen = 6
-
-	if len(buf) < minSummaryLen {
+	idx := indexOf(buf, []byte("ORA-"))
+	if idx < 0 {
 		return
 	}
 
-	retCode, _ := readCompressedInt(buf)
-	if retCode != 0 {
-		resp.OracleErr = retCode
+	end := idx
+	for end < len(buf) && buf[end] != 0x00 && buf[end] != 0x0A {
+		end++
 	}
 
-	if idx := indexOf(buf, []byte("ORA-")); idx >= 0 {
-		end := idx
-		for end < len(buf) && buf[end] != 0x00 && buf[end] != 0x0A {
-			end++
-		}
+	resp.OracleErrText = string(buf[idx:end])
 
-		resp.OracleErrText = string(buf[idx:end])
+	if end-idx >= 4+5 {
+		if code, err := strconv.Atoi(string(buf[idx+4 : idx+4+5])); err == nil {
+			resp.OracleErr = code
+		}
 	}
 }
 

--- a/internal/proxy/oracle/upstream_auth_client_test.go
+++ b/internal/proxy/oracle/upstream_auth_client_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha512"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"log/slog"
@@ -463,12 +462,9 @@ func buildSyntheticAuthPhase1Response(encServerKey, salt, csk, vgen, sder string
 		{"AUTH_PBKDF2_SDER_COUNT", sder, 0},
 	}
 
-	dictLenBuf := make([]byte, 2)
-	binary.BigEndian.PutUint16(dictLenBuf, uint16(len(pairs)))
-
 	buf := make([]byte, 0, 256)
 	buf = append(buf, 0x08)
-	buf = append(buf, dictLenBuf...)
+	buf = append(buf, ttcCompressedUint(uint64(len(pairs)))...)
 
 	for _, p := range pairs {
 		buf = append(buf, ttcKeyVal(p.key, p.value, p.flag)...)

--- a/specs/done/2026/05/sqlcl-post-auth-ora-03120.md
+++ b/specs/done/2026/05/sqlcl-post-auth-ora-03120.md
@@ -72,11 +72,31 @@ Would only work if (1) we can observe SQLcl's negotiated caps during the relay a
 ## Acceptance criteria
 
 - [x] Code path implemented and unit-tested end-to-end (crypto chain, wire shape, parser).
-- [x] go-ora end-to-end through dbbat: validated locally against Oracle 19c (`abyla_abynonprod`) — uses the new relay-socket-o5logon path; query intercepted, result returned.
+- [x] go-ora end-to-end through dbbat: validated locally against Oracle 19c (`abyla_abynonprod`); query intercepted, result returned.
 - [x] python-oracledb thin end-to-end through dbbat: validated locally — uses the relay-socket path + per-session AUTH_SVR_RESPONSE patch; previous DPY-4035 resolved.
-- [ ] **SQLcl end-to-end through dbbat: still blocked, but the failure mode shifted.** Phase-1-rewrite (forwarding the client's own Phase 1 with the username swapped to the upstream DB user) is now implemented for all clients, including SQLcl. With it, the upstream accepts dbbat's Phase 1 and replies with a normal challenge — but for SQLcl that challenge is verifier 6949 with the upstream's `customHash` flag set yet no `AUTH_PBKDF2_*` fields. dbbat falls back to the legacy MD5/XOR password-key derivation, the upstream rejects Phase 2 with end-of-call code 4, and SQLcl ends up at ORA-17401 via the captured-AUTH-OK fallback. The remaining gap is the password-key derivation variant Oracle expects for `verifier 6949 + customHash + no PBKDF2 fields` — JDBC thin's source for that derivation needs reverse-engineering (a Java stack trace per `feedback_jdbc_oracle_trace.md` would identify it).
+- [ ] **SQLcl end-to-end through dbbat: still blocked.** Pre-auth relay completes; the upstream then sends two TNS Marker (interrupt + reset) packets in response to dbbat's hand-built Phase 1. Both go-ora and python-oracledb work because the TTC caps the upstream negotiated with them match dbbat's own Phase 1 wire shape; SQLcl negotiates richer JDBC-thin caps so the upstream rejects dbbat's go-ora-style Phase 1 mid-parse. The fix is **Phase-1 forwarding**: take SQLcl's actual Phase 1 packet, swap the username field to the stored DB user, and forward as-is. Roughly the approach of the dropped 5294b37 commit, but kept minimal.
 - [x] The Oracle compatibility table in `docs/oracle.md` updated.
 - [x] python-oracledb thin no-regression: validated locally end-to-end.
+
+## Update 2026-05-07: regression fix landed; SQLcl still blocked at upstream Phase 1
+
+While reproducing the SQLcl failure locally, three regressions in the upstream-auth parser were found and fixed (`internal/proxy/oracle/upstream_auth_client.go`):
+
+1. `parseAuthKVDictionary` was reading the dictionary length as a **raw 2-byte big-endian uint** when Oracle's wire format is a TTC compressed integer. dbbat read `01 06` as 262 instead of 6 and tried to consume 262 KV pairs.
+2. `parseAuthSummary` treated the first compressed-int after code 0x04 / 0x09 as the Oracle error code. That field is actually `EndOfCallStatus` — for Phase 1 challenge responses Oracle sets it to 1 (continuation needed) with `RetCode=0`. dbbat misreported the success as ORA-00001.
+3. `parseAuthMessageStream` waited for an end-of-call code 0x04 / 0x09 after the 0x08 dictionary, but Phase 2 responses interleave additional TTC messages (notably code 0x17 server-network-info) before the trailing 0x04. The new logic returns success after consuming the first 0x08 dictionary, which carries everything we need for either phase.
+
+Plus a fourth gap that python-oracledb thin and SQLcl both validated and rejected: dbbat was sending a static `capturedAuthOKResponse` blob to the client. Modern clients verify the embedded AUTH_SVR_RESPONSE field by AES-decrypting it under the negotiated O5LOGON combined key — and the captured blob's value was encrypted under a different key. The fix forwards the upstream's real AUTH OK packet with AUTH_SVR_RESPONSE re-encrypted under the client's combined key (`internal/proxy/oracle/auth_svr_response.go`).
+
+Validated locally against Oracle 19c (`oracle-abynonprod.db.stonal.io`):
+
+| Client | Before | After |
+|--------|--------|-------|
+| go-ora v2.9.0 | hangs 60s, upstream RST (`read: connection reset by peer`) | works |
+| python-oracledb thin 3.4 | DPY-4035 (invalid server response) | works |
+| SQLcl 26.1 (JDBC thin 23.7) | ORA-17401 | upstream sends TNS Markers in response to Phase 1; same end-state but the failure now lives at upstream Phase 1 acceptance, not AUTH OK validation |
+
+The SQLcl path forward is now just **Phase-1 forwarding** (not the broader "find the right verifier-6949+customHash derivation" rabbit hole that the original spec sketched). Picking up that work means: capture SQLcl's Phase 1 from the relay handoff (already available as `phase1Pkt`), locate the username field, splice in the upstream DB user, write the modified packet to the upstream socket. The Phase 2 path is unchanged because dbbat continues to drive Phase 2 with its own crypto.
 
 ## Local validation setup (2026-05-06)
 


### PR DESCRIPTION
## Summary

Three latent parser bugs in the relay-socket O5LOGON CLIENT path (PR #129) and one missing AUTH OK patcher meant that **on current main, every Oracle client was broken end-to-end**:

| Client | Before | After |
|--------|--------|-------|
| go-ora v2.9.0 | 60 s hang, upstream RST | works |
| python-oracledb thin 3.4 | DPY-4035 (invalid server response) | works |
| SQLcl 26.1 (JDBC thin 23.7) | ORA-17401 | ORA-17401 (failure now lives at upstream Phase 1, not AUTH OK validation) |

Validated locally against Oracle 19c (`oracle-abynonprod.db.stonal.io`).

The merged spec `specs/done/2026/05/sqlcl-post-auth-ora-03120.md` claimed go-ora and python-oracledb worked on main; that was true on the WIP branch dropped in #134, not on what shipped. This PR brings the actually-working state forward.

## What changed

`internal/proxy/oracle/upstream_auth_client.go`:

- `parseAuthKVDictionary` now reads the dictionary length as a TTC compressed integer (matching go-ora's `session.GetInt(2, true, true)`), not a raw 2-byte big-endian uint. dbbat had decoded `01 06` as 262 instead of 6 and looped trying to consume 262 KV pairs.
- `parseAuthSummary` no longer interprets the leading `EndOfCallStatus` field as the Oracle error code. Phase 1 challenge responses set it to 1 with `RetCode=0`; previously dbbat reported that as ORA-00001.
- `parseAuthMessageStream` returns success after consuming the first 0x08 dictionary instead of waiting for an end-of-call 0x04 / 0x09. Phase 2 responses interleave a code 0x17 server-network-info message before the trailing 0x04, which previously caused the parser to silently keep reading until upstream RST.

`internal/proxy/oracle/auth_svr_response.go` (new):

- Replaces the static `capturedAuthOKResponse` write with the upstream's real Phase 2 packet, with AUTH_SVR_RESPONSE re-encrypted under the client's negotiated O5LOGON combined key. Without this, modern clients reject the AUTH OK because the captured response carries an AUTH_SVR_RESPONSE encrypted with someone else's combined key.

`internal/proxy/oracle/o5logon.go`:

- `O5LogonServer.DecryptPassword` now publishes the negotiated combined key as `O5LogonServer.CombinedKey` so the session can reuse it in the AUTH OK forwarded back.

`internal/proxy/oracle/session.go`:

- New `clientCombinedKey` and `upstreamAuthOKResponse` fields plus the AUTH OK forwarding logic.

`specs/done/2026/05/sqlcl-post-auth-ora-03120.md`:

- Updated acceptance criteria + an "Update 2026-05-07" section documenting the diagnosis and the now-clearer Phase-1-forwarding path forward for SQLcl.

## Test plan

- [x] `go build ./...`
- [x] `make lint` — 0 issues
- [x] Unit tests: 241 oracle-package tests pass
- [x] Real-Oracle validation: go-ora and python-oracledb thin both authenticate and `SELECT banner FROM v$version` end-to-end through dbbat (oracle-abynonprod, LABEOMNGR_DEV)
- [x] SQLcl 26.1 fails at the new boundary (upstream Phase 1 acceptance) — same ORA-17401 surface error but a different mode of failure that the spec covers

🤖 Generated with [Claude Code](https://claude.com/claude-code)