### PR TITLE
feat(oracle): forward client's actual Phase 1 to upstream

### DIFF
--- a/internal/proxy/oracle/phase1_forward.go
+++ b/internal/proxy/oracle/phase1_forward.go
@@ -1,0 +1,122 @@
+package oracle
+
+import (
+	"errors"
+	"fmt"
+)
+
+// rewriteAuthPhase1Username takes a TTC AUTH Phase 1 body (everything after
+// the TNS frame header AND the 2-byte data-flags prefix — i.e. what would
+// follow ttcDataFlagsSize in pkt.Payload) and returns a new body in which the
+// embedded username has been replaced with newUsername.
+//
+// Both wire encodings observed in the wild are preserved:
+//
+//   - go-ora / python-oracledb: 1-byte CLR length prefix followed by the
+//     username bytes (matches PutClr for short strings).
+//   - SQLcl JDBC thin: bare username bytes with no length prefix; the
+//     length is given solely by the leading user_id_len compressed integer.
+//
+// Splicing keeps the original encoding style of the client; userLen is
+// updated to the new username length.
+//
+// The rewritten body is returned as a fresh slice; the input is not
+// mutated. An error is returned if the body does not look like AUTH Phase 1
+// or the username field cannot be located. KV pairs that follow the
+// username (AUTH_TERMINAL, AUTH_PROGRAM_NM, ...) are passed through
+// unchanged so the upstream sees the client's actual TTC capabilities.
+func rewriteAuthPhase1Username(body []byte, newUsername string) ([]byte, error) {
+	const headerLen = 4 // [03 76 b0 b1] piggyback marker + sub-op + 2-byte trailer
+
+	if len(body) < headerLen {
+		return nil, fmt.Errorf("%w: body too short for header", ErrAuthPhase1Rewrite)
+	}
+
+	if body[0] != byte(TTCFuncPiggyback) || body[1] != PiggybackSubAuth1 {
+		return nil, fmt.Errorf("%w: not a Phase 1 piggyback", ErrAuthPhase1Rewrite)
+	}
+
+	rest := body[headerLen:]
+
+	userLen, n := readCompressedInt(rest)
+	if n == 0 || userLen <= 0 || userLen > 128 {
+		return nil, fmt.Errorf("%w: invalid user_id_len", ErrAuthPhase1Rewrite)
+	}
+
+	userLenBytes := n
+	rest = rest[n:]
+
+	_, n = readCompressedInt(rest)
+	if n == 0 {
+		return nil, fmt.Errorf("%w: missing logon_mode", ErrAuthPhase1Rewrite)
+	}
+
+	modeBytes := n
+	rest = rest[n:]
+
+	const magicLen = 5
+	if len(rest) < magicLen {
+		return nil, fmt.Errorf("%w: missing 5-byte magic", ErrAuthPhase1Rewrite)
+	}
+
+	rest = rest[magicLen:]
+
+	hasCLRPrefix, usernameBytes := detectUsernameEncoding(rest, userLen)
+
+	consumed := userLen
+	if hasCLRPrefix {
+		consumed = userLen + 1
+	}
+
+	if len(rest) < consumed {
+		return nil, fmt.Errorf("%w: username field truncated", ErrAuthPhase1Rewrite)
+	}
+
+	tail := rest[consumed:]
+
+	// Reassemble: header + new userLen + mode + magic + new username field + tail (KV pairs).
+	preMagicLen := headerLen + userLenBytes + modeBytes + magicLen
+
+	preMagic := body[:preMagicLen]
+	// preMagic still contains the OLD userLen — we need to splice in the new one.
+	headerSection := preMagic[:headerLen]
+	modeAndMagic := preMagic[headerLen+userLenBytes:]
+
+	newUserLen := ttcCompressedUint(uint64(len(newUsername)))
+
+	out := make([]byte, 0, len(headerSection)+len(newUserLen)+len(modeAndMagic)+1+len(newUsername)+len(tail))
+	out = append(out, headerSection...)
+	out = append(out, newUserLen...)
+	out = append(out, modeAndMagic...)
+
+	if hasCLRPrefix {
+		out = append(out, byte(len(newUsername)))
+	}
+
+	out = append(out, []byte(newUsername)...)
+	out = append(out, tail...)
+
+	_ = usernameBytes // sole purpose of detectUsernameEncoding's second return is documentation
+
+	return out, nil
+}
+
+// detectUsernameEncoding determines whether the Phase 1 body uses the
+// CLR-prefixed form (1-byte length followed by username) or the bare form
+// (raw bytes). Returns (hasPrefix, usernameBytes). The usernameBytes return
+// is informational; callers replace the field wholesale.
+func detectUsernameEncoding(rest []byte, userLen int) (bool, []byte) {
+	if len(rest) >= userLen+1 && int(rest[0]) == userLen && isPrintableASCII(rest[1:1+userLen]) {
+		return true, rest[1 : 1+userLen]
+	}
+
+	if len(rest) >= userLen && isPrintableASCII(rest[:userLen]) {
+		return false, rest[:userLen]
+	}
+
+	return false, nil
+}
+
+// ErrAuthPhase1Rewrite signals a Phase 1 body that does not match the
+// expected piggyback/sub-op/userLen/mode/magic/username layout.
+var ErrAuthPhase1Rewrite = errors.New("AUTH Phase 1 rewrite failed")

--- a/internal/proxy/oracle/phase1_forward_test.go
+++ b/internal/proxy/oracle/phase1_forward_test.go
@@ -1,0 +1,91 @@
+package oracle
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestRewriteAuthPhase1Username_BareEncoding covers SQLcl's wire shape: no CLR
+// length prefix on the username (the leading user_id_len compressed integer
+// is sole authority on length).
+func TestRewriteAuthPhase1Username_BareEncoding(t *testing.T) {
+	t.Parallel()
+
+	body := buildPhase1Body(t, "CONNECTOR", false)
+
+	out, err := rewriteAuthPhase1Username(body, "LABEOMNGR_DEV")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	expected := buildPhase1Body(t, "LABEOMNGR_DEV", false)
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("bare-encoding rewrite mismatch:\n got %x\nwant %x", out, expected)
+	}
+}
+
+// TestRewriteAuthPhase1Username_CLREncoding covers go-ora / python-oracledb's
+// wire shape: 1-byte CLR length prefix followed by the username bytes.
+func TestRewriteAuthPhase1Username_CLREncoding(t *testing.T) {
+	t.Parallel()
+
+	body := buildPhase1Body(t, "connector", true)
+
+	out, err := rewriteAuthPhase1Username(body, "LABEOMNGR_DEV")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	expected := buildPhase1Body(t, "LABEOMNGR_DEV", true)
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("CLR-encoding rewrite mismatch:\n got %x\nwant %x", out, expected)
+	}
+}
+
+// TestRewriteAuthPhase1Username_Errors covers the obvious malformed-input
+// cases — too-short body, wrong piggyback marker, and an absurd user_id_len.
+func TestRewriteAuthPhase1Username_Errors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"empty", nil},
+		{"truncated header", []byte{0x03, 0x76}},
+		{"wrong func code", []byte{0x05, 0x76, 0x00, 0x01, 0x01, 0x09}},
+		{"absurd userIDLen", append([]byte{byte(TTCFuncPiggyback), PiggybackSubAuth1, 0x00, 0x01}, 0x02, 0xff, 0xff)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := rewriteAuthPhase1Username(tc.body, "X"); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+// buildPhase1Body returns a TTC AUTH Phase 1 body matching the wire layout
+// `[03 76 00 01] [userLen] [mode] [magic] [(CLR-prefix?) username] [trailing
+// KV-pair bytes]`. The trailing bytes are a fixed sentinel so tests can
+// confirm they are passed through unchanged.
+func buildPhase1Body(t *testing.T, username string, withCLRPrefix bool) []byte {
+	t.Helper()
+
+	buf := []byte{byte(TTCFuncPiggyback), PiggybackSubAuth1, 0x00, 0x01}
+	buf = append(buf, ttcCompressedUint(uint64(len(username)))...)
+	buf = append(buf, ttcCompressedUint(1)...)
+	buf = append(buf, 0x01, 0x01, 0x05, 0x01, 0x01)
+
+	if withCLRPrefix {
+		buf = append(buf, byte(len(username)))
+	}
+
+	buf = append(buf, []byte(username)...)
+	buf = append(buf, []byte("__KV_TAIL__")...)
+
+	return buf
+}

--- a/internal/proxy/oracle/session.go
+++ b/internal/proxy/oracle/session.go
@@ -57,6 +57,14 @@ type session struct {
 	// AUTH OK forwarded to the client after AUTH_SVR_RESPONSE patching.
 	upstreamAuthOKResponse []byte
 
+	// clientAuthPhase1Pkt is the actual AUTH Phase 1 packet the client (SQLcl,
+	// go-ora, python-oracledb) sent during pre-auth relay. dbbat reuses its
+	// wire-shape (with the username swapped to the upstream DB user) when
+	// driving Phase 1 against the upstream socket so the TTC-cap-conditioned
+	// upstream parser accepts it. nil for legacy paths that read Phase 1
+	// directly from the client connection.
+	clientAuthPhase1Pkt *TNSPacket
+
 	// Query tracking
 	tracker      *oracleQueryTracker
 	queryStorage config.QueryStorageConfig
@@ -127,6 +135,7 @@ func (s *session) run() error {
 	}
 
 	s.upstreamConn = upstreamConn
+	s.clientAuthPhase1Pkt = phase1Pkt
 
 	// Step 5: Authenticate client via O5LOGON (API key as Oracle password)
 	if err := s.authenticateClient(phase1Pkt); err != nil {

--- a/internal/proxy/oracle/upstream_auth_client.go
+++ b/internal/proxy/oracle/upstream_auth_client.go
@@ -68,8 +68,7 @@ func (s *session) runUpstreamClientAuth() error {
 	password := s.database.Password
 	mode := uint32(logonModeNoNewPass)
 
-	phase1 := buildClientAuthPhase1(username, identity, mode)
-	if err := s.writeUpstreamData(phase1); err != nil {
+	if err := s.sendUpstreamAuthPhase1(username, identity, mode); err != nil {
 		return fmt.Errorf("write upstream AUTH Phase 1: %w", err)
 	}
 
@@ -111,6 +110,66 @@ func (s *session) runUpstreamClientAuth() error {
 		slog.String("user", s.database.Username),
 		slog.Int("verifier_type", sec.verifierType),
 		slog.Bool("custom_hash", sec.customHash))
+
+	return nil
+}
+
+// sendUpstreamAuthPhase1 writes the upstream-facing AUTH Phase 1 packet.
+//
+// When the relay handed us the client's actual Phase 1 packet, we forward
+// it with only the username field swapped to the upstream DB user
+// (rewriteAuthPhase1Username) and the original data-flag bits preserved.
+// Reusing the client's wire shape — flags, TTC trailer, KV-pair set —
+// keeps the upstream's TTC-cap-conditioned parser happy (clients negotiate
+// caps differently; SQLcl's JDBC thin Set Data Types is substantially
+// richer than go-ora's, and a hand-built go-ora-style Phase 1 fed to a
+// SQLcl-conditioned upstream draws a TNS Marker (interrupt + reset) pair
+// followed by a 60-second silence ending in RST).
+//
+// When phase1Pkt is unavailable (legacy non-relay path / tests) we fall
+// back to the synthetic builder with `00 00` data flags.
+func (s *session) sendUpstreamAuthPhase1(username string, identity driverIdentity, mode uint32) error {
+	if s.clientAuthPhase1Pkt == nil || len(s.clientAuthPhase1Pkt.Payload) <= ttcDataFlagsSize {
+		return s.writeUpstreamData(buildClientAuthPhase1(username, identity, mode))
+	}
+
+	clientPayload := s.clientAuthPhase1Pkt.Payload
+	dataFlags := clientPayload[:ttcDataFlagsSize]
+	clientBody := clientPayload[ttcDataFlagsSize:]
+
+	rewritten, err := rewriteAuthPhase1Username(clientBody, username)
+	if err != nil {
+		s.logger.WarnContext(s.ctx, "Phase 1 rewrite failed; falling back to synthetic Phase 1",
+			slog.Any("error", err))
+
+		return s.writeUpstreamData(buildClientAuthPhase1(username, identity, mode))
+	}
+
+	s.logger.DebugContext(s.ctx, "upstream AUTH: forwarding rewritten client Phase 1",
+		slog.Int("original_body_len", len(clientBody)),
+		slog.Int("rewritten_body_len", len(rewritten)),
+		slog.String("upstream_user", username))
+
+	full := make([]byte, 0, ttcDataFlagsSize+len(rewritten))
+	full = append(full, dataFlags...)
+	full = append(full, rewritten...)
+
+	return s.writeUpstreamPayload(full)
+}
+
+// writeUpstreamPayload writes a v315+ TNS Data packet whose payload is given
+// in full (including the leading 2 data-flag bytes). Used by Phase 1
+// forwarding so the client's data-flag bits are preserved verbatim.
+func (s *session) writeUpstreamPayload(payload []byte) error {
+	pkt := encodeV315DataPacket(payload)
+
+	s.logger.DebugContext(s.ctx, "upstream AUTH: writing packet (preserved flags)",
+		slog.Int("pkt_len", len(pkt)),
+		slog.Int("payload_len", len(payload)))
+
+	if _, err := s.upstreamConn.Write(pkt); err != nil {
+		return fmt.Errorf("upstream write: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Replaces the synthetic `buildClientAuthPhase1` path with one that takes the client's actual Phase 1 packet from the pre-auth relay handoff and splices in the upstream DB user. The client's wire shape — data-flag bits, TTC trailer, KV-pair set — is preserved verbatim so the upstream's TTC-cap-conditioned parser sees a Phase 1 that matches what it just negotiated `Set Protocol` / `Set Data Types` against.

Without this, a hand-built go-ora-style Phase 1 fed to a SQLcl-conditioned upstream draws a TNS Marker (interrupt + reset) pair followed by a 60-second silence ending in RST.

| Client | Before | After |
|--------|--------|-------|
| go-ora v2.9.0 | works | works (no regression) |
| python-oracledb thin 3.4 | works | works (no regression) |
| SQLcl 26.1 (JDBC thin 23.7) | upstream sends TNS Markers in response to dbbat's Phase 1; ORA-17401 | upstream completes both phases, dbbat forwards AUTH OK with patched AUTH_SVR_RESPONSE; **JDBC's `T4CTTIfun.receive` then trips the protocol-violation default case (still ORA-17401)** |

This is foundation work for SQLcl. The remaining ORA-17401 — captured via a tiny ojdbc11 stack-trace harness — is in JDBC's response parser, after every previously-known failure mode. That's a separate investigation.

## What changed

`internal/proxy/oracle/phase1_forward.go` (new):

- `rewriteAuthPhase1Username` returns a fresh body with the username swapped. Handles both wire encodings observed in the wild:
  - go-ora / python-oracledb thin: 1-byte CLR length prefix followed by the username bytes.
  - SQLcl JDBC thin: bare username bytes; length comes solely from the leading `user_id_len` compressed integer.

`internal/proxy/oracle/upstream_auth_client.go`:

- `sendUpstreamAuthPhase1` chooses between forwarding the rewritten client Phase 1 and (legacy) building a synthetic one. Phase 2 path is unchanged — dbbat continues to drive the crypto.
- `writeUpstreamPayload` preserves the client's original data-flag bits (SQLcl uses `0x0800` = `TNS_DATA_FLAGS_END_OF_REQUEST`; go-ora uses `0x0000`).

`internal/proxy/oracle/session.go`:

- New `clientAuthPhase1Pkt *TNSPacket` field captured at the relay handoff.

`internal/proxy/oracle/phase1_forward_test.go` (new):

- 7 tests covering both encodings + the obvious malformed-input cases.

## Test plan

- [x] `go build ./...`
- [x] `make lint` — 0 issues
- [x] Unit tests: 248 oracle-package tests pass (7 new)
- [x] Real-Oracle validation against `oracle-abynonprod`:
  - `go run gooracheck.go` — `OK: Oracle Database 19c…`
  - `python3 -c 'import oracledb; …'` — `OK: Oracle Database 19c…`
  - SQLcl 26.1 — fails further along the AUTH flow than before; documented in the PR body and committed JDBC stack trace recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)