### PR TITLE
feat(oracle): customHash mode in O5LOGON server (drops the verifier-downgrade strip)

### DIFF
--- a/internal/proxy/oracle/o5logon.go
+++ b/internal/proxy/oracle/o5logon.go
@@ -19,6 +19,20 @@ const (
 	o5LogonVerifierType      = "6949" // SHA-1 based verifier (legacy, used in value suffix)
 	o5LogonVerifierTypeNum   = 6949   // Verifier type sent as KV pair flag
 	o5LogonPasswordPrefixLen = 16     // Random prefix prepended to password by client
+
+	// o5LogonPbkdf2ChkSaltLen is the length of AUTH_PBKDF2_CSK_SALT in bytes
+	// (32-character hex on the wire). go-ora rejects values whose hex form is
+	// any other length (`network.NewOracleError(28041)`), so this is fixed.
+	o5LogonPbkdf2ChkSaltLen = 16
+
+	// Iteration counts advertised in AUTH_PBKDF2_VGEN_COUNT / SDER_COUNT.
+	// Matches what real Oracle 19c sends and what go-ora's auth_object.go
+	// clamps to. dbbat-as-server doesn't actually iterate VGEN itself (the
+	// verifier_key is precomputed in legacy 6949 form at API key creation
+	// time), but advertising 4096 keeps clients from clamping to a different
+	// minimum which would mismatch our derivation if they cached the value.
+	o5LogonDefaultPbkdf2VgenCount = 4096
+	o5LogonDefaultPbkdf2SderCount = 3
 )
 
 // O5LogonServer implements server-side O5LOGON authentication.
@@ -28,9 +42,28 @@ type O5LogonServer struct {
 	verifierKey      []byte // 24-byte key derived from password+salt
 	serverSessionKey []byte // 48-byte random (generated per auth)
 
-	// CombinedKey is set by DecryptPassword to MD5(serverSessKey || clientSessKey)
-	// derived from both session keys after a successful Phase 2. It is the AES key
-	// the client expects for AUTH_SVR_RESPONSE in the AUTH OK forwarded back.
+	// customHash, when true, has GenerateChallenge advertise AUTH_PBKDF2_*
+	// fields and DecryptPassword switch to the PBKDF2-derived combined-key
+	// path. Mirrors the customHash branch dbbat already implements on the
+	// upstream-as-client side; matches what real Oracle 19c does on the
+	// wire when caps[4]&0x20 is set in the Set Protocol response. Without
+	// this we have to strip the bit before forwarding to the client and
+	// the upstream then downgrades to verifier 6949 with no PBKDF2 fields,
+	// breaking SQLcl Phase 2.
+	customHash bool
+
+	// pbkdf2ChkSalt is generated per session when customHash is true, sent
+	// as AUTH_PBKDF2_CSK_SALT in the challenge, and reused in
+	// DecryptPassword to derive the combined key.
+	pbkdf2ChkSalt []byte
+
+	pbkdf2VgenCount int
+	pbkdf2SderCount int
+
+	// CombinedKey is set by DecryptPassword to the negotiated combined key
+	// — either MD5/XOR (legacy) or the PBKDF2-customHash derivation. It is
+	// the AES key the client expects for AUTH_SVR_RESPONSE in the AUTH OK
+	// forwarded back.
 	CombinedKey []byte
 }
 
@@ -50,18 +83,61 @@ func deriveVerifierKey(password string, salt []byte) []byte {
 // NewO5LogonServer creates a server from stored verifier data.
 func NewO5LogonServer(salt, verifierKey []byte) *O5LogonServer {
 	return &O5LogonServer{
-		salt:        salt,
-		verifierKey: verifierKey,
+		salt:            salt,
+		verifierKey:     verifierKey,
+		pbkdf2VgenCount: o5LogonDefaultPbkdf2VgenCount,
+		pbkdf2SderCount: o5LogonDefaultPbkdf2SderCount,
 	}
 }
 
+// EnableCustomHash switches the server into customHash mode. GenerateChallenge
+// will then advertise per-session AUTH_PBKDF2_CSK_SALT / VGEN_COUNT / SDER_COUNT
+// fields and DecryptPassword will use the PBKDF2-customHash combined-key
+// derivation. Used when the upstream's Set Protocol response had caps[4]&0x20
+// set — keeping the bit on the client side avoids the verifier-6949 downgrade
+// that real Oracle emits when the client signals "no customHash support".
+func (s *O5LogonServer) EnableCustomHash() {
+	s.customHash = true
+}
+
+// CustomHashEnabled reports whether the server is in customHash mode. Used by
+// the challenge builder to decide whether to include AUTH_PBKDF2_* fields.
+func (s *O5LogonServer) CustomHashEnabled() bool {
+	return s.customHash
+}
+
+// PBKDF2ChkSalt returns the per-session salt as an uppercase hex string.
+// Empty until GenerateChallenge has run in customHash mode.
+func (s *O5LogonServer) PBKDF2ChkSalt() string {
+	return strings.ToUpper(hex.EncodeToString(s.pbkdf2ChkSalt))
+}
+
+// PBKDF2VgenCount returns the verifier-generation iteration count advertised
+// in the challenge as AUTH_PBKDF2_VGEN_COUNT.
+func (s *O5LogonServer) PBKDF2VgenCount() int { return s.pbkdf2VgenCount }
+
+// PBKDF2SderCount returns the session-key-derivation iteration count
+// advertised in the challenge as AUTH_PBKDF2_SDER_COUNT.
+func (s *O5LogonServer) PBKDF2SderCount() int { return s.pbkdf2SderCount }
+
 // GenerateChallenge produces the AUTH_SESSKEY and AUTH_VFR_DATA for the client.
 // Returns hex-encoded encrypted server session key and auth verifier data.
+//
+// In customHash mode it also generates a fresh AUTH_PBKDF2_CSK_SALT (accessible
+// via PBKDF2ChkSalt) so the caller can include the matching KV fields in the
+// Phase 1 challenge sent on the wire.
 func (s *O5LogonServer) GenerateChallenge() (string, string, error) {
 	// Generate random server session key
 	s.serverSessionKey = make([]byte, o5LogonSessionKeyLength)
 	if _, err := rand.Read(s.serverSessionKey); err != nil {
 		return "", "", fmt.Errorf("failed to generate server session key: %w", err)
+	}
+
+	if s.customHash {
+		s.pbkdf2ChkSalt = make([]byte, o5LogonPbkdf2ChkSaltLen)
+		if _, err := rand.Read(s.pbkdf2ChkSalt); err != nil {
+			return "", "", fmt.Errorf("failed to generate AUTH_PBKDF2_CSK_SALT: %w", err)
+		}
 	}
 
 	// Derive encryption key from verifier key
@@ -84,7 +160,15 @@ func (s *O5LogonServer) GenerateChallenge() (string, string, error) {
 
 // DecryptPassword extracts the plaintext password from the client's AUTH Phase 2.
 // The client encrypts: random_prefix(16 bytes) + password using AES-192-CBC
-// with a key derived from MD5(server_session_key || client_session_key).
+// with a combined key derived from both session keys.
+//
+// In customHash mode the server attempts both the customHash combined-key
+// derivation (matching go-ora and JDBC, where the server-advertised customHash
+// bit and the AUTH_PBKDF2_* fields are honored) and the legacy MD5/XOR path
+// (matching python-oracledb thin, which always picks legacy when the
+// session_key is 48 bytes regardless of caps[4]&0x20). The first candidate
+// that yields a printable plaintext password wins. Out of customHash mode,
+// only the legacy path is tried.
 //
 // Side-effect: on success, the negotiated combined key is stored on the
 // receiver as CombinedKey so callers can reuse it (e.g. to encrypt
@@ -104,32 +188,75 @@ func (s *O5LogonServer) DecryptPassword(encClientSessKey, encPassword string) (s
 		return "", fmt.Errorf("failed to decrypt client session key: %w", err)
 	}
 
-	// Derive combined key from both session keys
-	combinedKey := deriveCombinedKey(s.serverSessionKey, clientSessionKey)
-	s.CombinedKey = combinedKey
-
-	// Decode and decrypt the password
 	encPasswordBytes, err := hex.DecodeString(encPassword)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode encrypted password: %w", err)
 	}
 
-	decryptedPassword, err := aes192CBCDecrypt(combinedKey, encPasswordBytes)
+	candidates := s.combinedKeyCandidates(clientSessionKey)
+
+	for _, key := range candidates {
+		password, ok := tryDecryptPasswordWithKey(key, encPasswordBytes)
+		if !ok {
+			continue
+		}
+
+		s.CombinedKey = key
+
+		return password, nil
+	}
+
+	return "", ErrDecryptedPasswordTooShort
+}
+
+// combinedKeyCandidates returns the combined-key derivations to try, in order
+// of likelihood for the current mode.
+//
+//   - customHash mode: customHash PBKDF2 derivation first (go-ora, JDBC), then
+//     legacy MD5/XOR (python-oracledb thin's verifier-6949 path is hard-coded
+//     to legacy regardless of customHash advertisement).
+//   - non-customHash mode: legacy only.
+func (s *O5LogonServer) combinedKeyCandidates(clientSessionKey []byte) [][]byte {
+	legacy := deriveCombinedKey(s.serverSessionKey, clientSessionKey)
+
+	if !s.customHash {
+		return [][]byte{legacy}
+	}
+
+	// customHash branch mirrors derivePasswordEncKey in upstream_auth_crypto.go:
+	// for verifier 6949 + customHash, joined = clientSessionKey[:24] ||
+	// serverSessionKey[:24], then chained HMAC-SHA512 over hex(joined) keyed
+	// with pbkdf2ChkSalt for sderCount turns, truncated to 24 bytes.
+	joined := append(append([]byte{}, clientSessionKey[:24]...), s.serverSessionKey[:24]...)
+	hexJoined := strings.ToUpper(hex.EncodeToString(joined))
+	customHashKey := pbkdf2SpeedyKey(s.pbkdf2ChkSalt, []byte(hexJoined), s.pbkdf2SderCount)[:24]
+
+	return [][]byte{customHashKey, legacy}
+}
+
+// tryDecryptPasswordWithKey attempts AES-192-CBC decryption of the encrypted
+// password with the supplied combined key. Returns the recovered password
+// (with prefix and null padding stripped) plus ok=true on success. ok=false
+// signals the candidate key produced an obviously wrong plaintext (too short
+// or non-printable).
+func tryDecryptPasswordWithKey(key, encPasswordBytes []byte) (string, bool) {
+	plaintext, err := aes192CBCDecrypt(key, encPasswordBytes)
 	if err != nil {
-		return "", fmt.Errorf("failed to decrypt password: %w", err)
+		return "", false
 	}
 
-	// Strip the 16-byte random prefix
-	if len(decryptedPassword) <= o5LogonPasswordPrefixLen {
-		return "", ErrDecryptedPasswordTooShort
+	if len(plaintext) <= o5LogonPasswordPrefixLen {
+		return "", false
 	}
 
-	// Remove random prefix and any null padding
-	password := decryptedPassword[o5LogonPasswordPrefixLen:]
-	// Trim null bytes from the end (PKCS padding remnants)
+	password := plaintext[o5LogonPasswordPrefixLen:]
 	password = trimNullBytes(password)
 
-	return string(password), nil
+	if len(password) == 0 || !isPrintableASCII(password) {
+		return "", false
+	}
+
+	return string(password), true
 }
 
 // deriveAESKey returns the verifier key zero-padded to 24 bytes for use as AES-192 key.

--- a/internal/proxy/oracle/relay_preauth.go
+++ b/internal/proxy/oracle/relay_preauth.go
@@ -87,37 +87,6 @@ func (s *session) relayPreAuthNegotiation(connectPkt *TNSPacket) (*TNSPacket, ne
 	}
 }
 
-// stripCustomHashFlag scans for the ServerCompileTimeCaps block in a Set Protocol
-// response and clears bit 5 (0x20) of caps[4] — the customHash flag that switches
-// modern clients to a PBKDF2 combined-key derivation dbbat doesn't implement.
-//
-// The block is preceded by `2a 06 01 01 01` (length+meta tags); caps[4] sits one
-// byte after that prefix. Verified against captured Oracle 19c traffic where
-// caps[4] = 0x6f.
-func stripCustomHashFlag(raw []byte) ([]byte, bool) {
-	marker := []byte{0x2a, 0x06, 0x01, 0x01, 0x01}
-
-	idx := bytes.Index(raw, marker)
-	if idx < 0 {
-		return raw, false
-	}
-
-	caps4Off := idx + len(marker)
-	if caps4Off >= len(raw) {
-		return raw, false
-	}
-
-	if raw[caps4Off]&0x20 == 0 {
-		return raw, false
-	}
-
-	mutated := make([]byte, len(raw))
-	copy(mutated, raw)
-	mutated[caps4Off] &^= 0x20
-
-	return mutated, true
-}
-
 // observeCustomHashFlag reports whether the Set Protocol response carries
 // caps[4]&0x20 (customHash). Used to remember the upstream's true cap level
 // before we mutate the bytes for the client.
@@ -159,22 +128,18 @@ func relayUpstreamResponses(s *session, upstream net.Conn) error {
 
 	// Set Protocol responses carry ServerCompileTimeCaps. caps[4]&0x20 enables
 	// a customHash (PBKDF2) combined-key derivation in modern Oracle clients
-	// (go-ora, JDBC thin, SQLcl). dbbat's O5LOGON server uses the simpler MD5
-	// XOR derivation; if we forward the bit set, the client's combined key
-	// won't match dbbat's and the AUTH_PASSWORD decryption produces garbage.
-	// Stripping the bit forces matching MD5 behavior on the client side.
+	// (go-ora, JDBC thin, SQLcl). dbbat's O5LOGON server now implements that
+	// derivation too (see EnableCustomHash on O5LogonServer), so we forward
+	// the bit unchanged: dbbat-as-server, the client, and the upstream all
+	// agree on customHash mode. Previously we stripped the bit to match
+	// dbbat's legacy-only server, which made the upstream emit verifier 6949
+	// with no PBKDF2 fields when the client subsequently advertised "no
+	// customHash support" — and broke SQLcl Phase 2 derivation.
 	//
-	// We still record the original bit on the session so the upstream-as-client
-	// AUTH path uses the modern PBKDF2 derivation that the upstream actually
-	// negotiated.
+	// We still record the bit on the session so authenticateClient can
+	// switch the O5LOGON server into customHash mode for this connection.
 	if observeCustomHashFlag(raw) {
 		s.upstreamCustomHash = true
-	}
-
-	if mutated, ok := stripCustomHashFlag(raw); ok {
-		s.logger.DebugContext(s.ctx, "pre-auth relay: stripped customHash flag from Set Protocol response")
-
-		raw = mutated
 	}
 
 	s.logger.DebugContext(s.ctx, "pre-auth relay: upstream→client",

--- a/internal/proxy/oracle/session.go
+++ b/internal/proxy/oracle/session.go
@@ -441,8 +441,18 @@ func (s *session) authenticateClient(phase1Pkt *TNSPacket) error {
 		return fmt.Errorf("failed to load O5LOGON verifier: %w", err)
 	}
 
-	// Generate O5LOGON challenge
+	// Generate O5LOGON challenge. When the upstream's Set Protocol response
+	// had caps[4]&0x20 set, we run customHash mode: the challenge advertises
+	// AUTH_PBKDF2_CSK_SALT / VGEN_COUNT / SDER_COUNT and DecryptPassword
+	// uses the PBKDF2 combined-key derivation. This keeps the customHash
+	// bit on for the client (no strip needed in the relay) so the upstream
+	// doesn't downgrade to verifier 6949 with no PBKDF2 fields when the
+	// client advertises modern caps in subsequent packets.
 	o5 := NewO5LogonServer(verifier.O5LogonSalt, verifier.decryptedVerifier)
+	if s.upstreamCustomHash {
+		o5.EnableCustomHash()
+	}
+
 	encSessKey, vfrData, err := o5.GenerateChallenge()
 	if err != nil {
 		return fmt.Errorf("failed to generate O5LOGON challenge: %w", err)
@@ -451,8 +461,9 @@ func (s *session) authenticateClient(phase1Pkt *TNSPacket) error {
 	// Send AUTH challenge to client
 	s.logger.DebugContext(s.ctx, "sending AUTH challenge",
 		slog.Int("sesskey_len", len(encSessKey)),
-		slog.Int("vfrdata_len", len(vfrData)))
-	challengePayload := buildAuthChallenge(encSessKey, vfrData)
+		slog.Int("vfrdata_len", len(vfrData)),
+		slog.Bool("custom_hash", o5.CustomHashEnabled()))
+	challengePayload := buildAuthChallenge(encSessKey, vfrData, o5.PBKDF2ChkSalt(), o5.PBKDF2VgenCount(), o5.PBKDF2SderCount())
 	challengePayload = append(challengePayload, buildAuthChallengeEndMarker()...)
 	s.logger.DebugContext(s.ctx, "AUTH challenge payload",
 		slog.Int("len", len(challengePayload)),

--- a/internal/proxy/oracle/ttc_auth.go
+++ b/internal/proxy/oracle/ttc_auth.go
@@ -2,15 +2,19 @@ package oracle
 
 import (
 	"encoding/binary"
+	"strconv"
 	"strings"
 )
 
 // TTC AUTH key names used in Oracle authentication messages.
 const (
-	authKeyUsername = "AUTH_TERMINAL"
-	authKeySessKey  = "AUTH_SESSKEY"
-	authKeyVfrData  = "AUTH_VFR_DATA"
-	authKeyPassword = "AUTH_PASSWORD"
+	authKeyUsername        = "AUTH_TERMINAL"
+	authKeySessKey         = "AUTH_SESSKEY"
+	authKeyVfrData         = "AUTH_VFR_DATA"
+	authKeyPassword        = "AUTH_PASSWORD"
+	authKeyPbkdf2CskSalt   = "AUTH_PBKDF2_CSK_SALT"
+	authKeyPbkdf2VgenCount = "AUTH_PBKDF2_VGEN_COUNT"
+	authKeyPbkdf2SderCount = "AUTH_PBKDF2_SDER_COUNT"
 )
 
 // authKVPair represents a key-value pair in a TTC AUTH message.
@@ -187,14 +191,29 @@ func isPrintableASCII(b []byte) bool {
 // buildAuthChallenge constructs the TTC AUTH challenge response using Oracle's
 // TTC wire encoding (compressed uint + CLR encoding).
 //
-// The challenge contains AUTH_SESSKEY and AUTH_VFR_DATA key-value pairs that the
-// client uses for O5LOGON authentication.
-func buildAuthChallenge(encServerSessKey, authVfrData string) []byte {
+// In customHash mode (pbkdf2ChkSaltHex non-empty), three extra KV pairs are
+// included: AUTH_PBKDF2_CSK_SALT plus AUTH_PBKDF2_VGEN_COUNT and
+// AUTH_PBKDF2_SDER_COUNT. Together they tell the client to derive the
+// combined key via PBKDF2 (matching what real Oracle 19c sends when
+// caps[4]&0x20 is set in the Set Protocol response).
+func buildAuthChallenge(encServerSessKey, authVfrData, pbkdf2ChkSaltHex string, vgenCount, sderCount int) []byte {
+	pairs := 2
+
+	if pbkdf2ChkSaltHex != "" {
+		pairs += 3
+	}
+
 	buf := make([]byte, 0, 256)
 	buf = append(buf, 0x00, 0x00, byte(TTCFuncResponse)) // data flags + 0x08
-	buf = append(buf, ttcCompressedUint(2)...)           // 2 KV pairs
+	buf = append(buf, ttcCompressedUint(uint64(pairs))...)
 	buf = append(buf, ttcKeyVal(authKeySessKey, encServerSessKey, 1)...)
 	buf = append(buf, ttcKeyVal(authKeyVfrData, authVfrData, o5LogonVerifierTypeNum)...)
+
+	if pbkdf2ChkSaltHex != "" {
+		buf = append(buf, ttcKeyVal(authKeyPbkdf2CskSalt, pbkdf2ChkSaltHex, 0)...)
+		buf = append(buf, ttcKeyVal(authKeyPbkdf2VgenCount, strconv.Itoa(vgenCount), 0)...)
+		buf = append(buf, ttcKeyVal(authKeyPbkdf2SderCount, strconv.Itoa(sderCount), 0)...)
+	}
 
 	return buf
 }


### PR DESCRIPTION
## Summary

Replaces the customHash bit strip in the pre-auth relay with a full server-side customHash implementation. The strip was the root cause of the SQLcl verifier-6949+no-PBKDF2 downgrade: clients saw a stripped Set Protocol response and adjusted cap advertisements, the upstream observed a "client doesn't support customHash" peer, and fell back to legacy verifier 6949 with no `AUTH_PBKDF2_*` fields. dbbat then PBKDF2'd with an empty `pbkdf2ChkSalt` and the upstream rejected Phase 2 with TNS Markers.

| Client | Before | After |
|--------|--------|-------|
| go-ora v2.9.0 | works | works (no regression) |
| python-oracledb thin 3.4 | works | works (no regression) |
| SQLcl 26.1 (JDBC thin 23.7) | upstream returns degraded verifier-6949 challenge → TNS Markers reject Phase 2 | upstream returns verifier 18453 + full AUTH_PBKDF2_* fields → both phases complete; AUTH OK validation still throws ORA-17401 (separate Phase-2 KV-pair gap) |

## What changed

`internal/proxy/oracle/o5logon.go`:

- New `EnableCustomHash()` and per-session `pbkdf2ChkSalt` (16 random bytes per AUTH).
- `GenerateChallenge` now advertises `AUTH_PBKDF2_CSK_SALT` / `VGEN_COUNT` / `SDER_COUNT` alongside `AUTH_SESSKEY` / `AUTH_VFR_DATA` when in customHash mode.
- `DecryptPassword` tries **multiple combined-key candidates** in order: customHash PBKDF2 first (matches go-ora and JDBC), then legacy MD5/XOR (matches python-oracledb thin, whose verifier-6949 path is hard-coded to legacy regardless of the customHash bit — confirmed by reading `auth.pyx` in the upstream `oracle/python-oracledb` repo). The candidate that yields a printable plaintext password wins.

`internal/proxy/oracle/relay_preauth.go`:

- Drops the `stripCustomHashFlag` mutation. `observeCustomHashFlag` still records the bit so `authenticateClient` can flip the O5LOGON server into customHash mode.

`internal/proxy/oracle/session.go`:

- `authenticateClient` enables customHash on the O5LOGON server when `s.upstreamCustomHash` is set.

`internal/proxy/oracle/ttc_auth.go`:

- `buildAuthChallenge` gains three new parameters for the PBKDF2 KV pairs.
- New `authKeyPbkdf2CskSalt` / `_VgenCount` / `_SderCount` constants.

## Test plan

- [x] `go build ./...`
- [x] `make lint` — 0 issues
- [x] Unit tests: 248 oracle-package tests pass
- [x] Real-Oracle validation against `oracle-abynonprod`: go-ora and python-oracledb thin both complete `SELECT banner FROM v$version`. SQLcl 26.1 reaches AUTH OK validation (further than before; ORA-17401 from JDBC's `T4CTTIfun.receive` side is the next investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)