### PR TITLE
feat(oracle): forward client's actual Phase 2 to upstream

### DIFF
--- a/internal/proxy/oracle/phase1_forward.go
+++ b/internal/proxy/oracle/phase1_forward.go
@@ -61,7 +61,7 @@ func rewriteAuthPhase1Username(body []byte, newUsername string) ([]byte, error) 
 
 	rest = rest[magicLen:]
 
-	hasCLRPrefix, usernameBytes := detectUsernameEncoding(rest, userLen)
+	hasCLRPrefix := detectUsernameEncoding(rest, userLen)
 
 	consumed := userLen
 	if hasCLRPrefix {
@@ -96,25 +96,23 @@ func rewriteAuthPhase1Username(body []byte, newUsername string) ([]byte, error) 
 	out = append(out, []byte(newUsername)...)
 	out = append(out, tail...)
 
-	_ = usernameBytes // sole purpose of detectUsernameEncoding's second return is documentation
-
 	return out, nil
 }
 
-// detectUsernameEncoding determines whether the Phase 1 body uses the
-// CLR-prefixed form (1-byte length followed by username) or the bare form
-// (raw bytes). Returns (hasPrefix, usernameBytes). The usernameBytes return
-// is informational; callers replace the field wholesale.
-func detectUsernameEncoding(rest []byte, userLen int) (bool, []byte) {
+// detectUsernameEncoding determines whether the buffer's username field uses
+// the CLR-prefixed form (1-byte length followed by username) or the bare form
+// (raw bytes). Used by both Phase 1 and Phase 2 forwarders to splice in a new
+// username while preserving the client's original encoding.
+func detectUsernameEncoding(rest []byte, userLen int) bool {
 	if len(rest) >= userLen+1 && int(rest[0]) == userLen && isPrintableASCII(rest[1:1+userLen]) {
-		return true, rest[1 : 1+userLen]
+		return true
 	}
 
 	if len(rest) >= userLen && isPrintableASCII(rest[:userLen]) {
-		return false, rest[:userLen]
+		return false
 	}
 
-	return false, nil
+	return false
 }
 
 // ErrAuthPhase1Rewrite signals a Phase 1 body that does not match the

--- a/internal/proxy/oracle/phase2_forward.go
+++ b/internal/proxy/oracle/phase2_forward.go
@@ -1,0 +1,223 @@
+package oracle
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// rewriteAuthPhase2 takes a TTC AUTH Phase 2 body (everything after the TNS
+// frame header AND the 2-byte data-flags prefix — i.e. what would follow
+// ttcDataFlagsSize in pkt.Payload) and returns a new body in which:
+//
+//   - The username is replaced with newUsername.
+//   - AUTH_SESSKEY value is replaced with sec.encClientSessKey.
+//   - AUTH_PASSWORD value is replaced with sec.encPassword.
+//   - AUTH_PBKDF2_SPEEDY_KEY value (when present) is replaced with sec.eSpeedyKey.
+//
+// All other KV pairs (AUTH_TERMINAL, AUTH_PROGRAM_NM, SESSION_CLIENT_DRIVER_NAME,
+// AUTH_CONNECT_STRING, AUTH_COPYRIGHT, AUTH_ACL, AUTH_ALTER_SESSION, …) are
+// passed through verbatim. This preserves the client's TTC capability surface
+// so the upstream's AUTH OK is conditioned on the client's actual identity
+// (notably: the AUTH_CONNECT_STRING / AUTH_ACL / driver-version triplet that
+// JDBC thin sends and which standard go-ora does not).
+//
+// Phase 2 wire layout for go-ora-style clients:
+//
+//	[03 73 b0]                 -- piggyback header + sub-op + 1 client-specific byte
+//	                              (0x00 for go-ora; 0x02 for JDBC thin)
+//	[01]                       -- has-username flag
+//	[compressed-int user_id_len]
+//	[compressed-int mode]
+//	[01]
+//	[compressed-int pair_count]
+//	[01 01]
+//	[username bare OR CLR-prefixed]
+//	[KV pairs...]
+//
+// Both observed username encodings are handled. The b0 byte at offset 2 is
+// preserved verbatim (its meaning is opaque; preserving it keeps the upstream's
+// caps-conditioned parser happy).
+//
+// The rewritten body is returned as a fresh slice; the input is not mutated.
+func rewriteAuthPhase2(body []byte, newUsername string, sec *upstreamAuthSecrets) ([]byte, error) {
+	const headerLen = 3 // [03 73 b0]
+
+	if len(body) < headerLen+1 {
+		return nil, fmt.Errorf("%w: body too short for header", ErrAuthPhase2Rewrite)
+	}
+
+	if body[0] != byte(TTCFuncPiggyback) || body[1] != PiggybackSubAuth2 {
+		return nil, fmt.Errorf("%w: not a Phase 2 piggyback", ErrAuthPhase2Rewrite)
+	}
+
+	pos := headerLen
+	hasUsername := body[pos] == 0x01
+	pos++
+
+	var userLen int
+
+	if hasUsername {
+		ul, n := readCompressedInt(body[pos:])
+		if n == 0 || ul <= 0 || ul > 128 {
+			return nil, fmt.Errorf("%w: invalid user_id_len", ErrAuthPhase2Rewrite)
+		}
+
+		userLen = ul
+		pos += n
+	} else {
+		// has-username==0 layout uses [00 00] in place of the [01 user_id_len].
+		if len(body) < pos+1 {
+			return nil, fmt.Errorf("%w: truncated zero user marker", ErrAuthPhase2Rewrite)
+		}
+
+		pos++
+	}
+
+	_, modeSize := readCompressedInt(body[pos:])
+	if modeSize == 0 {
+		return nil, fmt.Errorf("%w: missing mode", ErrAuthPhase2Rewrite)
+	}
+
+	modeStart := pos
+	pos += modeSize
+
+	if pos >= len(body) {
+		return nil, fmt.Errorf("%w: truncated after mode", ErrAuthPhase2Rewrite)
+	}
+
+	// Skip 1-byte padding (always 0x01).
+	pos++
+
+	pairCount, pairCountSize := readCompressedInt(body[pos:])
+	if pairCountSize == 0 || pairCount < 0 {
+		return nil, fmt.Errorf("%w: invalid pair_count", ErrAuthPhase2Rewrite)
+	}
+
+	pos += pairCountSize
+
+	if pos+2 > len(body) {
+		return nil, fmt.Errorf("%w: truncated 0x01 0x01 marker", ErrAuthPhase2Rewrite)
+	}
+
+	// Skip 0x01 0x01.
+	pos += 2
+
+	usernameEnd := pos
+	hasCLRPrefix := false
+
+	if hasUsername {
+		hasCLRPrefix, _ = detectUsernameEncoding(body[pos:], userLen)
+
+		consumed := userLen
+		if hasCLRPrefix {
+			consumed = userLen + 1
+		}
+
+		if len(body) < pos+consumed {
+			return nil, fmt.Errorf("%w: username field truncated", ErrAuthPhase2Rewrite)
+		}
+
+		usernameEnd = pos + consumed
+	}
+
+	// Walk and rewrite KV pairs.
+	rewrittenPairs, err := rewritePhase2KVPairs(body[usernameEnd:], pairCount, sec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Reassemble the body.
+	out := make([]byte, 0, len(body)+len(newUsername))
+
+	// Header [03 73 b0] — preserve b0 verbatim (varies by client).
+	out = append(out, body[:headerLen]...)
+
+	if hasUsername {
+		// has-username flag.
+		out = append(out, 0x01)
+		out = append(out, ttcCompressedUint(uint64(len(newUsername)))...)
+	} else {
+		out = append(out, 0x00, 0x00)
+	}
+
+	// Mode (verbatim — same NoNewPass | UserAndPass bits).
+	out = append(out, body[modeStart:modeStart+modeSize]...)
+
+	// 0x01 byte after mode.
+	out = append(out, 0x01)
+	// Pair count (verbatim).
+	out = append(out, ttcCompressedUint(uint64(pairCount))...)
+	// 0x01 0x01 marker.
+	out = append(out, 0x01, 0x01)
+
+	// Username — preserve original encoding (bare for JDBC, CLR-prefixed for go-ora).
+	if hasUsername {
+		if hasCLRPrefix {
+			out = append(out, byte(len(newUsername)))
+		}
+
+		out = append(out, []byte(newUsername)...)
+	}
+
+	out = append(out, rewrittenPairs...)
+
+	return out, nil
+}
+
+// rewritePhase2KVPairs walks pairCount TTC KV pairs in buf and returns a slice
+// in which the AUTH_SESSKEY / AUTH_PASSWORD / AUTH_PBKDF2_SPEEDY_KEY values
+// have been swapped to the upstream-derived ones in sec. Other pairs are
+// copied verbatim.
+//
+// On any decoding error, returns ErrAuthPhase2Rewrite.
+func rewritePhase2KVPairs(buf []byte, pairCount int, sec *upstreamAuthSecrets) ([]byte, error) {
+	out := make([]byte, 0, len(buf))
+	pos := 0
+
+	for i := 0; i < pairCount; i++ {
+		if pos >= len(buf) {
+			return nil, fmt.Errorf("%w: truncated at pair %d/%d", ErrAuthPhase2Rewrite, i, pairCount)
+		}
+
+		pair, ok := readAuthKVPair(buf[pos:])
+		if !ok {
+			return nil, fmt.Errorf("%w: bad pair %d/%d", ErrAuthPhase2Rewrite, i, pairCount)
+		}
+
+		newValue, replaced := upstreamPhase2Value(string(pair.Key), sec)
+		if replaced {
+			out = append(out, ttcKeyVal(string(pair.Key), newValue, pair.Flag)...)
+		} else {
+			out = append(out, buf[pos:pos+pair.Consumed]...)
+		}
+
+		pos += pair.Consumed
+	}
+
+	return out, nil
+}
+
+// upstreamPhase2Value returns the upstream-derived value for an AUTH_*-key the
+// client sent. ok=false signals "leave verbatim".
+func upstreamPhase2Value(key string, sec *upstreamAuthSecrets) (string, bool) {
+	switch strings.ToUpper(key) {
+	case authKeySessKey:
+		return sec.encClientSessKey, true
+	case authKeyPassword:
+		return sec.encPassword, true
+	case pbkdf2SpeedyKeyLabel:
+		if sec.eSpeedyKey == "" {
+			return "", false
+		}
+
+		return sec.eSpeedyKey, true
+	}
+
+	return "", false
+}
+
+// ErrAuthPhase2Rewrite signals a Phase 2 body that does not match the
+// expected piggyback / has-username / user_id_len / mode / pair_count layout
+// or whose KV pairs cannot be parsed.
+var ErrAuthPhase2Rewrite = errors.New("AUTH Phase 2 rewrite failed")

--- a/internal/proxy/oracle/phase2_forward.go
+++ b/internal/proxy/oracle/phase2_forward.go
@@ -41,49 +41,66 @@ import (
 //
 // The rewritten body is returned as a fresh slice; the input is not mutated.
 func rewriteAuthPhase2(body []byte, newUsername string, sec *upstreamAuthSecrets) ([]byte, error) {
+	hdr, err := parseAuthPhase2Header(body)
+	if err != nil {
+		return nil, err
+	}
+
+	rewrittenPairs, err := rewritePhase2KVPairs(body[hdr.usernameEnd:], hdr.pairCount, sec)
+	if err != nil {
+		return nil, err
+	}
+
+	return assembleAuthPhase2(body, hdr, newUsername, rewrittenPairs), nil
+}
+
+// authPhase2Header captures the byte boundaries needed to splice in a new
+// username and KV-pair set.
+type authPhase2Header struct {
+	hasUsername  bool
+	hasCLRPrefix bool
+	modeStart    int
+	modeSize     int
+	pairCount    int
+	usernameEnd  int
+}
+
+// parseAuthPhase2Header walks the Phase 2 preamble — header bytes, has-username
+// flag, user_id_len, mode, pair_count, marker, and username field — returning
+// the offsets needed to reassemble the body.
+func parseAuthPhase2Header(body []byte) (authPhase2Header, error) {
 	const headerLen = 3 // [03 73 b0]
 
+	out := authPhase2Header{}
+
 	if len(body) < headerLen+1 {
-		return nil, fmt.Errorf("%w: body too short for header", ErrAuthPhase2Rewrite)
+		return out, fmt.Errorf("%w: body too short for header", ErrAuthPhase2Rewrite)
 	}
 
 	if body[0] != byte(TTCFuncPiggyback) || body[1] != PiggybackSubAuth2 {
-		return nil, fmt.Errorf("%w: not a Phase 2 piggyback", ErrAuthPhase2Rewrite)
+		return out, fmt.Errorf("%w: not a Phase 2 piggyback", ErrAuthPhase2Rewrite)
 	}
 
 	pos := headerLen
-	hasUsername := body[pos] == 0x01
+	out.hasUsername = body[pos] == 0x01
 	pos++
 
-	var userLen int
-
-	if hasUsername {
-		ul, n := readCompressedInt(body[pos:])
-		if n == 0 || ul <= 0 || ul > 128 {
-			return nil, fmt.Errorf("%w: invalid user_id_len", ErrAuthPhase2Rewrite)
-		}
-
-		userLen = ul
-		pos += n
-	} else {
-		// has-username==0 layout uses [00 00] in place of the [01 user_id_len].
-		if len(body) < pos+1 {
-			return nil, fmt.Errorf("%w: truncated zero user marker", ErrAuthPhase2Rewrite)
-		}
-
-		pos++
+	userLen, err := readPhase2UserLen(body, &pos, out.hasUsername)
+	if err != nil {
+		return out, err
 	}
 
 	_, modeSize := readCompressedInt(body[pos:])
 	if modeSize == 0 {
-		return nil, fmt.Errorf("%w: missing mode", ErrAuthPhase2Rewrite)
+		return out, fmt.Errorf("%w: missing mode", ErrAuthPhase2Rewrite)
 	}
 
-	modeStart := pos
+	out.modeStart = pos
+	out.modeSize = modeSize
 	pos += modeSize
 
 	if pos >= len(body) {
-		return nil, fmt.Errorf("%w: truncated after mode", ErrAuthPhase2Rewrite)
+		return out, fmt.Errorf("%w: truncated after mode", ErrAuthPhase2Rewrite)
 	}
 
 	// Skip 1-byte padding (always 0x01).
@@ -91,69 +108,85 @@ func rewriteAuthPhase2(body []byte, newUsername string, sec *upstreamAuthSecrets
 
 	pairCount, pairCountSize := readCompressedInt(body[pos:])
 	if pairCountSize == 0 || pairCount < 0 {
-		return nil, fmt.Errorf("%w: invalid pair_count", ErrAuthPhase2Rewrite)
+		return out, fmt.Errorf("%w: invalid pair_count", ErrAuthPhase2Rewrite)
 	}
 
+	out.pairCount = pairCount
 	pos += pairCountSize
 
 	if pos+2 > len(body) {
-		return nil, fmt.Errorf("%w: truncated 0x01 0x01 marker", ErrAuthPhase2Rewrite)
+		return out, fmt.Errorf("%w: truncated 0x01 0x01 marker", ErrAuthPhase2Rewrite)
 	}
 
 	// Skip 0x01 0x01.
 	pos += 2
 
-	usernameEnd := pos
-	hasCLRPrefix := false
+	out.usernameEnd = pos
 
-	if hasUsername {
-		hasCLRPrefix, _ = detectUsernameEncoding(body[pos:], userLen)
+	if out.hasUsername {
+		out.hasCLRPrefix = detectUsernameEncoding(body[pos:], userLen)
 
 		consumed := userLen
-		if hasCLRPrefix {
+		if out.hasCLRPrefix {
 			consumed = userLen + 1
 		}
 
 		if len(body) < pos+consumed {
-			return nil, fmt.Errorf("%w: username field truncated", ErrAuthPhase2Rewrite)
+			return out, fmt.Errorf("%w: username field truncated", ErrAuthPhase2Rewrite)
 		}
 
-		usernameEnd = pos + consumed
+		out.usernameEnd = pos + consumed
 	}
 
-	// Walk and rewrite KV pairs.
-	rewrittenPairs, err := rewritePhase2KVPairs(body[usernameEnd:], pairCount, sec)
-	if err != nil {
-		return nil, err
+	return out, nil
+}
+
+// readPhase2UserLen advances pos past the user_id_len field and returns the
+// length value (0 when hasUsername is false, in which case it skips a single
+// padding byte instead).
+func readPhase2UserLen(body []byte, pos *int, hasUsername bool) (int, error) {
+	if !hasUsername {
+		if len(body) < *pos+1 {
+			return 0, fmt.Errorf("%w: truncated zero user marker", ErrAuthPhase2Rewrite)
+		}
+
+		*pos++
+
+		return 0, nil
 	}
 
-	// Reassemble the body.
+	ul, n := readCompressedInt(body[*pos:])
+	if n == 0 || ul <= 0 || ul > 128 {
+		return 0, fmt.Errorf("%w: invalid user_id_len", ErrAuthPhase2Rewrite)
+	}
+
+	*pos += n
+
+	return ul, nil
+}
+
+// assembleAuthPhase2 builds the rewritten body with the new username and
+// pre-rewritten KV pairs, preserving the original header / mode / marker bytes.
+func assembleAuthPhase2(body []byte, hdr authPhase2Header, newUsername string, rewrittenPairs []byte) []byte {
+	const headerLen = 3
+
 	out := make([]byte, 0, len(body)+len(newUsername))
-
-	// Header [03 73 b0] — preserve b0 verbatim (varies by client).
 	out = append(out, body[:headerLen]...)
 
-	if hasUsername {
-		// has-username flag.
+	if hdr.hasUsername {
 		out = append(out, 0x01)
 		out = append(out, ttcCompressedUint(uint64(len(newUsername)))...)
 	} else {
 		out = append(out, 0x00, 0x00)
 	}
 
-	// Mode (verbatim — same NoNewPass | UserAndPass bits).
-	out = append(out, body[modeStart:modeStart+modeSize]...)
-
-	// 0x01 byte after mode.
+	out = append(out, body[hdr.modeStart:hdr.modeStart+hdr.modeSize]...)
 	out = append(out, 0x01)
-	// Pair count (verbatim).
-	out = append(out, ttcCompressedUint(uint64(pairCount))...)
-	// 0x01 0x01 marker.
+	out = append(out, ttcCompressedUint(uint64(hdr.pairCount))...)
 	out = append(out, 0x01, 0x01)
 
-	// Username — preserve original encoding (bare for JDBC, CLR-prefixed for go-ora).
-	if hasUsername {
-		if hasCLRPrefix {
+	if hdr.hasUsername {
+		if hdr.hasCLRPrefix {
 			out = append(out, byte(len(newUsername)))
 		}
 
@@ -162,7 +195,7 @@ func rewriteAuthPhase2(body []byte, newUsername string, sec *upstreamAuthSecrets
 
 	out = append(out, rewrittenPairs...)
 
-	return out, nil
+	return out
 }
 
 // rewritePhase2KVPairs walks pairCount TTC KV pairs in buf and returns a slice

--- a/internal/proxy/oracle/phase2_forward_test.go
+++ b/internal/proxy/oracle/phase2_forward_test.go
@@ -1,0 +1,271 @@
+package oracle
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// TestRewriteAuthPhase2_BasicSwap_CLR confirms the three load-bearing AUTH_*
+// values are replaced with upstream-derived ones and other KV pairs pass
+// through verbatim. CLR-prefixed username (go-ora-style).
+func TestRewriteAuthPhase2_BasicSwap_CLR(t *testing.T) {
+	t.Parallel()
+
+	pairs := []phase2KVForTest{
+		{"AUTH_PASSWORD", "OLDPWD_HEX", 0},
+		{"AUTH_PBKDF2_SPEEDY_KEY", "OLDSPEEDY_HEX", 0},
+		{"AUTH_SESSKEY", "OLDSESS_HEX", 1},
+		{"AUTH_TERMINAL", "unknown", 0},
+		{"AUTH_PROGRAM_NM", "SourceLauncher", 0},
+		{"AUTH_CONNECT_STRING", "(DESCRIPTION=...)", 0},
+		{"AUTH_COPYRIGHT", "Oracle blah", 0},
+		{"AUTH_ACL", "4400", 0},
+	}
+	body := buildPhase2Body(t, "CONNECTOR", 0x101, pairs, true /*CLR*/, 0x00 /*b0*/)
+
+	sec := &upstreamAuthSecrets{
+		encClientSessKey: "NEWSESS_HEX",
+		encPassword:      "NEWPWD_HEX",
+		eSpeedyKey:       "NEWSPEEDY_HEX",
+	}
+
+	out, err := rewriteAuthPhase2(body, "LABEOMNGR_DEV", sec)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	expectedPairs := []phase2KVForTest{
+		{"AUTH_PASSWORD", "NEWPWD_HEX", 0},
+		{"AUTH_PBKDF2_SPEEDY_KEY", "NEWSPEEDY_HEX", 0},
+		{"AUTH_SESSKEY", "NEWSESS_HEX", 1},
+		{"AUTH_TERMINAL", "unknown", 0},
+		{"AUTH_PROGRAM_NM", "SourceLauncher", 0},
+		{"AUTH_CONNECT_STRING", "(DESCRIPTION=...)", 0},
+		{"AUTH_COPYRIGHT", "Oracle blah", 0},
+		{"AUTH_ACL", "4400", 0},
+	}
+	expected := buildPhase2Body(t, "LABEOMNGR_DEV", 0x101, expectedPairs, true, 0x00)
+
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("phase 2 rewrite mismatch:\n got %x\nwant %x", out, expected)
+	}
+}
+
+// TestRewriteAuthPhase2_BasicSwap_Bare covers the JDBC-thin wire shape: bare
+// username (no CLR length prefix) and a 0x02 byte at offset 2 of the body.
+// The b0 byte must be preserved verbatim.
+func TestRewriteAuthPhase2_BasicSwap_Bare(t *testing.T) {
+	t.Parallel()
+
+	pairs := []phase2KVForTest{
+		{"AUTH_SESSKEY", "OLDSESS_HEX", 1},
+		{"AUTH_PASSWORD", "OLDPWD_HEX", 0},
+	}
+	body := buildPhase2Body(t, "CONNECTOR", 0x101, pairs, false /*bare*/, 0x02 /*b0*/)
+
+	sec := &upstreamAuthSecrets{
+		encClientSessKey: "NEWSESS_HEX",
+		encPassword:      "NEWPWD_HEX",
+	}
+
+	out, err := rewriteAuthPhase2(body, "LABEOMNGR_DEV", sec)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	expectedPairs := []phase2KVForTest{
+		{"AUTH_SESSKEY", "NEWSESS_HEX", 1},
+		{"AUTH_PASSWORD", "NEWPWD_HEX", 0},
+	}
+	expected := buildPhase2Body(t, "LABEOMNGR_DEV", 0x101, expectedPairs, false, 0x02)
+
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("phase 2 bare-rewrite mismatch:\n got %x\nwant %x", out, expected)
+	}
+}
+
+// TestRewriteAuthPhase2_NoSpeedyKey confirms the SPEEDY_KEY pair is left
+// verbatim when the upstream secrets don't have one (verifier 6949 path).
+func TestRewriteAuthPhase2_NoSpeedyKey(t *testing.T) {
+	t.Parallel()
+
+	pairs := []phase2KVForTest{
+		{"AUTH_PASSWORD", "OLDPWD_HEX", 0},
+		{"AUTH_SESSKEY", "OLDSESS_HEX", 1},
+		{"AUTH_TERMINAL", "unknown", 0},
+	}
+	body := buildPhase2Body(t, "CONNECTOR", 0x101, pairs, true, 0x00)
+
+	sec := &upstreamAuthSecrets{
+		encClientSessKey: "NEWSESS_HEX",
+		encPassword:      "NEWPWD_HEX",
+		eSpeedyKey:       "", // verifier 6949
+	}
+
+	out, err := rewriteAuthPhase2(body, "USR2", sec)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	expectedPairs := []phase2KVForTest{
+		{"AUTH_PASSWORD", "NEWPWD_HEX", 0},
+		{"AUTH_SESSKEY", "NEWSESS_HEX", 1},
+		{"AUTH_TERMINAL", "unknown", 0},
+	}
+	expected := buildPhase2Body(t, "USR2", 0x101, expectedPairs, true, 0x00)
+
+	if !bytes.Equal(out, expected) {
+		t.Fatalf("phase 2 rewrite mismatch:\n got %x\nwant %x", out, expected)
+	}
+}
+
+// TestRewriteAuthPhase2_RealJDBC verifies the parser handles the actual
+// SQLcl/JDBC thin Phase 2 captured from a real upstream session.
+//
+// Captured body (after 2-byte data flags): 1187 bytes from the wire trace at
+// /tmp/sniff_p2.log line 16. Username is "LABEOMNGR_DEV" and we substitute
+// "NEWUSER_X" plus all three AUTH_* values.
+func TestRewriteAuthPhase2_RealJDBC(t *testing.T) {
+	t.Parallel()
+
+	// Real JDBC Phase 2 body from sniff_p2.log line 16 (after data flags).
+	bodyHex := "03730201010d02010101010e01014c4142454f4d4e47525f444556" +
+		"010d0d415554485f50415353574f524401606032374244333444344237393842353531313737414644413743323132434145444330393636364144413232443130333037453631373039343832333842383032443631464546463837393544314235303945423032423938453444453134384600" +
+		"011616415554485f50424b4446325f5350454544595f4b455901a0a03630383130414632463044334632424344443632333731423836413744304434453236343541413335324138383736304239424339394230303245454632394645373338383144343846333935373830314435423146373243314641374535424233363836433733453342393242424444394334353338414332304538333441424245414434324337413331423132364446434445414537393636393337373500" +
+		"010c0c415554485f534553534b45590140403943384245353736363937303038383539434431373130443935433537454233304333343641434145313641374433363342383937363535393131323838414601" +
+		"01010d0d415554485f5445524d494e414c010707756e6b6e6f776e00" +
+		"010f0f415554485f50524f4752414d5f4e4d010e0e536f757263654c61756e6368657200" +
+		"010c0c415554485f4d414348494e45011a1a466c6f72656e74732d4d6163426f6f6b2d4169722e6c6f63616c00" +
+		"010808415554485f5049440104043132333400" +
+		"011212415554485f414c5445525f53455353494f4e015c5c414c5445522053455353494f4e205345542054494d455f5a4f4e453d274575726f70652f506172697327204e4c535f4c414e47554147453d27414d45524943414e2720204e4c535f5445525249544f52593d27414d455249434127000101" +
+		"011a1a53455353494f4e5f434c49454e545f4452495645525f4e414d450117176a6462637468696e203a2032332e372e302e32352e303100" +
+		"01161653455353494f4e5f434c49454e545f56455253494f4e0109093338363333353132310001161653455353494f4e5f434c49454e545f4c4f4241545452010101310001131" +
+		"3415554485f434f4e4e4543545f535452494e47016565284445534352495054494f4e3d28414444524553533d2850524f544f434f4c3d5443502928484f53543d6c6f63616c686f73742928504f52543d31353330292928434f4e4e4543545f444154413d28534552564943455f4e414d453d54455354303129292900" +
+		"010e0e415554485f434f5059524947485401f1f1224f7261636c650a4576657279626f647920666f6c6c6f77730a53706565647920626974732065786368616e67650a537461727320617761697420746f20676c6f77220a54686520707265636564696e67206b657920697320636f707972696768746564206279204f7261636c6520436f72706f726174696f6e2e0a4475706c69636174696f6e206f662074686973206b6579206973206e6f7420616c6c6f77656420776974686f7574207065726d697373696f6e0a66726f6d204f7261636c6520436f72706f726174696f6e2e20436f707972696768742032303033204f7261636c6520436f72706f726174696f6e2e00" +
+		"010808415554485f41434c0104043434303000"
+
+	body, err := hex.DecodeString(strings.ReplaceAll(bodyHex, " ", ""))
+	if err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	sec := &upstreamAuthSecrets{
+		encClientSessKey: "NEW_SESSION_KEY_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		encPassword:      "NEW_PASSWORD_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+		eSpeedyKey:       "NEW_SPEEDY_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+	}
+
+	out, err := rewriteAuthPhase2(body, "NEWUSER_X", sec)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	// Output must be a valid Phase 2 body that round-trips through the
+	// existing parseAuthPhase2 parser.
+	withFlags := append([]byte{0x00, 0x00}, out...)
+
+	gotSess, gotPwd, err := parseAuthPhase2(withFlags)
+	if err != nil {
+		t.Fatalf("parseAuthPhase2 on rewritten body: %v", err)
+	}
+
+	if gotSess != sec.encClientSessKey {
+		t.Errorf("AUTH_SESSKEY: got %q want %q", gotSess, sec.encClientSessKey)
+	}
+
+	if gotPwd != sec.encPassword {
+		t.Errorf("AUTH_PASSWORD: got %q want %q", gotPwd, sec.encPassword)
+	}
+
+	// Verify untouched KV pairs survived: AUTH_CONNECT_STRING / AUTH_ACL /
+	// AUTH_COPYRIGHT must still be present.
+	if !bytes.Contains(out, []byte("AUTH_CONNECT_STRING")) {
+		t.Error("AUTH_CONNECT_STRING missing from rewritten body")
+	}
+
+	if !bytes.Contains(out, []byte("AUTH_COPYRIGHT")) {
+		t.Error("AUTH_COPYRIGHT missing from rewritten body")
+	}
+
+	if !bytes.Contains(out, []byte("AUTH_ACL")) {
+		t.Error("AUTH_ACL missing from rewritten body")
+	}
+
+	if !bytes.Contains(out, []byte("NEWUSER_X")) {
+		t.Error("substituted username not in rewritten body")
+	}
+
+	if bytes.Contains(out, []byte("LABEOMNGR_DEV")) {
+		t.Error("original username still present in rewritten body")
+	}
+}
+
+// TestRewriteAuthPhase2_Errors covers obviously malformed bodies.
+func TestRewriteAuthPhase2_Errors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"empty", nil},
+		{"truncated header", []byte{0x03, 0x73}},
+		{"wrong sub-op", []byte{0x03, 0x76, 0x00, 0x01, 0x01, 0x09}},
+	}
+
+	sec := &upstreamAuthSecrets{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := rewriteAuthPhase2(tc.body, "X", sec); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+// phase2KVForTest is a test helper for building Phase 2 bodies.
+type phase2KVForTest struct {
+	key, value string
+	flag       int
+}
+
+// buildPhase2Body returns a TTC AUTH Phase 2 body. When clrUsername is true
+// the username is CLR-prefixed (go-ora-style); otherwise it's bare (JDBC
+// thin-style). b0 is the byte at offset 2 (0x00 for go-ora, 0x02 for JDBC).
+func buildPhase2Body(t *testing.T, username string, mode uint32, pairs []phase2KVForTest, clrUsername bool, b0 byte) []byte {
+	t.Helper()
+
+	usernameBytes := []byte(username)
+
+	buf := []byte{byte(TTCFuncPiggyback), PiggybackSubAuth2, b0}
+
+	if len(usernameBytes) > 0 {
+		buf = append(buf, 0x01)
+		buf = append(buf, ttcCompressedUint(uint64(len(usernameBytes)))...)
+	} else {
+		buf = append(buf, 0x00, 0x00)
+	}
+
+	buf = append(buf, ttcCompressedUint(uint64(mode))...)
+	buf = append(buf, 0x01)
+	buf = append(buf, ttcCompressedUint(uint64(len(pairs)))...)
+	buf = append(buf, 0x01, 0x01)
+
+	if len(usernameBytes) > 0 {
+		if clrUsername {
+			buf = append(buf, byte(len(usernameBytes)))
+		}
+
+		buf = append(buf, usernameBytes...)
+	}
+
+	for _, p := range pairs {
+		buf = append(buf, ttcKeyVal(p.key, p.value, p.flag)...)
+	}
+
+	return buf
+}

--- a/internal/proxy/oracle/phase2_forward_test.go
+++ b/internal/proxy/oracle/phase2_forward_test.go
@@ -23,7 +23,7 @@ func TestRewriteAuthPhase2_BasicSwap_CLR(t *testing.T) {
 		{"AUTH_COPYRIGHT", "Oracle blah", 0},
 		{"AUTH_ACL", "4400", 0},
 	}
-	body := buildPhase2Body(t, "CONNECTOR", 0x101, pairs, true /*CLR*/, 0x00 /*b0*/)
+	body := buildPhase2Body(t, "CONNECTOR", pairs, true /*CLR*/, 0x00 /*b0*/)
 
 	sec := &upstreamAuthSecrets{
 		encClientSessKey: "NEWSESS_HEX",
@@ -46,7 +46,7 @@ func TestRewriteAuthPhase2_BasicSwap_CLR(t *testing.T) {
 		{"AUTH_COPYRIGHT", "Oracle blah", 0},
 		{"AUTH_ACL", "4400", 0},
 	}
-	expected := buildPhase2Body(t, "LABEOMNGR_DEV", 0x101, expectedPairs, true, 0x00)
+	expected := buildPhase2Body(t, "LABEOMNGR_DEV", expectedPairs, true, 0x00)
 
 	if !bytes.Equal(out, expected) {
 		t.Fatalf("phase 2 rewrite mismatch:\n got %x\nwant %x", out, expected)
@@ -63,7 +63,7 @@ func TestRewriteAuthPhase2_BasicSwap_Bare(t *testing.T) {
 		{"AUTH_SESSKEY", "OLDSESS_HEX", 1},
 		{"AUTH_PASSWORD", "OLDPWD_HEX", 0},
 	}
-	body := buildPhase2Body(t, "CONNECTOR", 0x101, pairs, false /*bare*/, 0x02 /*b0*/)
+	body := buildPhase2Body(t, "CONNECTOR", pairs, false /*bare*/, 0x02 /*b0*/)
 
 	sec := &upstreamAuthSecrets{
 		encClientSessKey: "NEWSESS_HEX",
@@ -79,7 +79,7 @@ func TestRewriteAuthPhase2_BasicSwap_Bare(t *testing.T) {
 		{"AUTH_SESSKEY", "NEWSESS_HEX", 1},
 		{"AUTH_PASSWORD", "NEWPWD_HEX", 0},
 	}
-	expected := buildPhase2Body(t, "LABEOMNGR_DEV", 0x101, expectedPairs, false, 0x02)
+	expected := buildPhase2Body(t, "LABEOMNGR_DEV", expectedPairs, false, 0x02)
 
 	if !bytes.Equal(out, expected) {
 		t.Fatalf("phase 2 bare-rewrite mismatch:\n got %x\nwant %x", out, expected)
@@ -96,7 +96,7 @@ func TestRewriteAuthPhase2_NoSpeedyKey(t *testing.T) {
 		{"AUTH_SESSKEY", "OLDSESS_HEX", 1},
 		{"AUTH_TERMINAL", "unknown", 0},
 	}
-	body := buildPhase2Body(t, "CONNECTOR", 0x101, pairs, true, 0x00)
+	body := buildPhase2Body(t, "CONNECTOR", pairs, true, 0x00)
 
 	sec := &upstreamAuthSecrets{
 		encClientSessKey: "NEWSESS_HEX",
@@ -114,7 +114,7 @@ func TestRewriteAuthPhase2_NoSpeedyKey(t *testing.T) {
 		{"AUTH_SESSKEY", "NEWSESS_HEX", 1},
 		{"AUTH_TERMINAL", "unknown", 0},
 	}
-	expected := buildPhase2Body(t, "USR2", 0x101, expectedPairs, true, 0x00)
+	expected := buildPhase2Body(t, "USR2", expectedPairs, true, 0x00)
 
 	if !bytes.Equal(out, expected) {
 		t.Fatalf("phase 2 rewrite mismatch:\n got %x\nwant %x", out, expected)
@@ -236,8 +236,12 @@ type phase2KVForTest struct {
 // buildPhase2Body returns a TTC AUTH Phase 2 body. When clrUsername is true
 // the username is CLR-prefixed (go-ora-style); otherwise it's bare (JDBC
 // thin-style). b0 is the byte at offset 2 (0x00 for go-ora, 0x02 for JDBC).
-func buildPhase2Body(t *testing.T, username string, mode uint32, pairs []phase2KVForTest, clrUsername bool, b0 byte) []byte {
+// Mode is hard-coded to 0x101 (UserAndPass | NoNewPass) — the only value
+// observed in real Phase 2 traffic.
+func buildPhase2Body(t *testing.T, username string, pairs []phase2KVForTest, clrUsername bool, b0 byte) []byte {
 	t.Helper()
+
+	const mode uint32 = 0x101
 
 	usernameBytes := []byte(username)
 

--- a/internal/proxy/oracle/session.go
+++ b/internal/proxy/oracle/session.go
@@ -65,6 +65,16 @@ type session struct {
 	// directly from the client connection.
 	clientAuthPhase1Pkt *TNSPacket
 
+	// clientAuthPhase2Pkt is the AUTH Phase 2 packet the client sent. dbbat
+	// reuses its wire-shape (with username + AUTH_SESSKEY/AUTH_PASSWORD/
+	// AUTH_PBKDF2_SPEEDY_KEY values swapped) when driving Phase 2 against the
+	// upstream socket. This carries the client-specific KV pairs the upstream
+	// conditions its AUTH OK on — notably AUTH_CONNECT_STRING, AUTH_COPYRIGHT,
+	// AUTH_ACL, and the SESSION_CLIENT_DRIVER_NAME / VERSION pair that JDBC
+	// thin sends. Without forwarding, dbbat's hand-built Phase 2 omits those
+	// and JDBC trips ORA-17401 in T4CTTIfun.receive.
+	clientAuthPhase2Pkt *TNSPacket
+
 	// Query tracking
 	tracker      *oracleQueryTracker
 	queryStorage config.QueryStorageConfig
@@ -479,6 +489,8 @@ func (s *session) authenticateClient(phase1Pkt *TNSPacket) error {
 	if err != nil {
 		return err
 	}
+
+	s.clientAuthPhase2Pkt = phase2Pkt
 
 	s.logger.DebugContext(s.ctx, "AUTH Phase 2 packet received",
 		slog.String("type", phase2Pkt.Type.String()),

--- a/internal/proxy/oracle/upstream_auth_client.go
+++ b/internal/proxy/oracle/upstream_auth_client.go
@@ -90,8 +90,7 @@ func (s *session) runUpstreamClientAuth() error {
 		return fmt.Errorf("derive upstream auth secrets: %w", err)
 	}
 
-	phase2 := buildClientAuthPhase2(username, identity, sec, mode|logonModeUserAndPass)
-	if err := s.writeUpstreamData(phase2); err != nil {
+	if err := s.sendUpstreamAuthPhase2(username, identity, sec, mode|logonModeUserAndPass); err != nil {
 		return fmt.Errorf("write upstream AUTH Phase 2: %w", err)
 	}
 
@@ -146,6 +145,52 @@ func (s *session) sendUpstreamAuthPhase1(username string, identity driverIdentit
 	}
 
 	s.logger.DebugContext(s.ctx, "upstream AUTH: forwarding rewritten client Phase 1",
+		slog.Int("original_body_len", len(clientBody)),
+		slog.Int("rewritten_body_len", len(rewritten)),
+		slog.String("upstream_user", username))
+
+	full := make([]byte, 0, ttcDataFlagsSize+len(rewritten))
+	full = append(full, dataFlags...)
+	full = append(full, rewritten...)
+
+	return s.writeUpstreamPayload(full)
+}
+
+// sendUpstreamAuthPhase2 writes the upstream-facing AUTH Phase 2 packet.
+//
+// When the relay handed us the client's actual Phase 2 packet, we forward
+// it with the username swapped to the upstream DB user and AUTH_SESSKEY /
+// AUTH_PASSWORD / AUTH_PBKDF2_SPEEDY_KEY values replaced with the upstream-
+// derived ones (rewriteAuthPhase2). All other KV pairs — AUTH_CONNECT_STRING,
+// AUTH_COPYRIGHT, AUTH_ACL, AUTH_ALTER_SESSION, the SESSION_CLIENT_DRIVER_*
+// triplet — pass through verbatim.
+//
+// This matters because the upstream's AUTH OK is conditioned on the client's
+// Phase 2 KV-pair set: JDBC thin sends a richer set than go-ora, and a
+// hand-built go-ora-style Phase 2 forwarded to a JDBC-conditioned upstream
+// produces an AUTH OK that JDBC's T4CTTIfun.receive default-cases on
+// (ORA-17401 protocol violation).
+//
+// When clientAuthPhase2Pkt is unavailable (legacy non-relay path / tests) we
+// fall back to the synthetic builder.
+func (s *session) sendUpstreamAuthPhase2(username string, identity driverIdentity, sec *upstreamAuthSecrets, mode uint32) error {
+	if s.clientAuthPhase2Pkt == nil || len(s.clientAuthPhase2Pkt.Payload) <= ttcDataFlagsSize {
+		return s.writeUpstreamData(buildClientAuthPhase2(username, identity, sec, mode))
+	}
+
+	clientPayload := s.clientAuthPhase2Pkt.Payload
+	dataFlags := clientPayload[:ttcDataFlagsSize]
+	clientBody := clientPayload[ttcDataFlagsSize:]
+
+	rewritten, err := rewriteAuthPhase2(clientBody, username, sec)
+	if err != nil {
+		s.logger.WarnContext(s.ctx, "Phase 2 rewrite failed; falling back to synthetic Phase 2",
+			slog.Any("error", err))
+
+		return s.writeUpstreamData(buildClientAuthPhase2(username, identity, sec, mode))
+	}
+
+	s.logger.DebugContext(s.ctx, "upstream AUTH: forwarding rewritten client Phase 2",
 		slog.Int("original_body_len", len(clientBody)),
 		slog.Int("rewritten_body_len", len(rewritten)),
 		slog.String("upstream_user", username))


### PR DESCRIPTION
## Summary

Mirror the Phase-1-forwarding design from #138 for AUTH Phase 2: when the relay captured the client's actual Phase 2 packet, splice in upstream-encrypted AUTH_SESSKEY / AUTH_PASSWORD / AUTH_PBKDF2_SPEEDY_KEY values and swap the username, leaving all other KV pairs verbatim.

SQLcl/JDBC thin sends 14 KV pairs in Phase 2 (1195 bytes total) — including AUTH_CONNECT_STRING, AUTH_COPYRIGHT, AUTH_ACL, and a JDBC-flavoured SESSION_CLIENT_DRIVER_NAME / VERSION / LOBATTR triplet. dbbat's hand-built `buildClientAuthPhase2` sends 12 (~870 bytes) and uses go-ora's static identity strings. The upstream's AUTH OK is conditioned on what was in Phase 2; the previous body produced an AUTH OK that JDBC's `T4CTTIfun.receive` default-cases on (ORA-17401 "internal protocol violation" at line 1048).

The forwarder also handles JDBC's bare-username encoding and `0x02` byte at offset 2 of the body — both differ from go-ora's CLR-prefixed username + `0x00` shape and must be preserved verbatim.

Falls back to the synthetic `buildClientAuthPhase2` when the rewrite fails or the relay didn't capture the Phase 2 packet (legacy non-relay path / tests).

## Test plan

- [x] Unit tests for both wire shapes (CLR-prefixed go-ora, bare JDBC) pass
- [x] Round-trip test against a real captured JDBC Phase 2 body (1187 bytes from a live SQLcl session)
- [x] Existing 254 oracle tests still pass
- [x] `golangci-lint run` clean
- [ ] End-to-end: SQLcl 26.1 connects through dbbat to a real Oracle 19c upstream without ORA-17401

🤖 Generated with [Claude Code](https://claude.com/claude-code)