### PR TITLE
feat(oracle): derive combined key for empty-AUTH_PASSWORD path

### DIFF
--- a/internal/proxy/oracle/errors.go
+++ b/internal/proxy/oracle/errors.go
@@ -94,6 +94,7 @@ var (
 
 	// O5LOGON and TTC auth errors.
 	ErrDecryptedPasswordTooShort = errors.New("decrypted password too short")
+	ErrNoCombinedKeyCandidate    = errors.New("no combined-key candidate available")
 	ErrCiphertextNotAligned      = errors.New("ciphertext is not a multiple of block size")
 	ErrInvalidPadding            = errors.New("invalid PKCS7 padding")
 	ErrAuthPhase1TooShort        = errors.New("AUTH Phase 1 payload too short")

--- a/internal/proxy/oracle/o5logon.go
+++ b/internal/proxy/oracle/o5logon.go
@@ -209,6 +209,39 @@ func (s *O5LogonServer) DecryptPassword(encClientSessKey, encPassword string) (s
 	return "", ErrDecryptedPasswordTooShort
 }
 
+// DeriveCombinedKey computes the combined-key the client used (the first
+// candidate per combinedKeyCandidates) and stores it on the receiver, without
+// requiring an AUTH_PASSWORD plaintext to verify against. Used by the
+// empty-AUTH_PASSWORD branch (SQLcl / JDBC thin 23c+) where the proxy has no
+// way to validate by password decryption — but still needs the combined key
+// so it can re-encrypt AUTH_SVR_RESPONSE before forwarding the upstream's
+// AUTH OK to the client.
+//
+// In customHash mode the customHash PBKDF2 derivation is preferred (matches
+// JDBC and go-ora). Otherwise the legacy MD5/XOR combined key is used.
+func (s *O5LogonServer) DeriveCombinedKey(encClientSessKey string) error {
+	encClientSessKeyBytes, err := hex.DecodeString(encClientSessKey)
+	if err != nil {
+		return fmt.Errorf("decode client session key: %w", err)
+	}
+
+	decKey := deriveAESKey(s.verifierKey)
+
+	clientSessionKey, err := aes192CBCDecrypt(decKey, encClientSessKeyBytes)
+	if err != nil {
+		return fmt.Errorf("decrypt client session key: %w", err)
+	}
+
+	candidates := s.combinedKeyCandidates(clientSessionKey)
+	if len(candidates) == 0 {
+		return ErrNoCombinedKeyCandidate
+	}
+
+	s.CombinedKey = candidates[0]
+
+	return nil
+}
+
 // combinedKeyCandidates returns the combined-key derivations to try, in order
 // of likelihood for the current mode.
 //

--- a/internal/proxy/oracle/session.go
+++ b/internal/proxy/oracle/session.go
@@ -377,6 +377,17 @@ func (s *session) resolveAPIKeyFromPhase2(o5 *O5LogonServer, verifier *o5LogonVe
 		s.logger.InfoContext(s.ctx, "AUTH Phase 2: empty AUTH_PASSWORD — using loaded verifier's API key",
 			slog.String("key_id", verifier.apiKeyID.String()))
 
+		// Derive the combined key the way the client did so the AUTH_SVR_RESPONSE
+		// patch can run. Without this, dbbat forwards the upstream's
+		// AUTH_SVR_RESPONSE verbatim — that ciphertext is encrypted under
+		// dbbat's upstream-side combined key, so JDBC's client-side decrypt
+		// returns garbage and fails the "SERVER_TO_CLIENT" marker check with
+		// ORA-17401.
+		if err := o5.DeriveCombinedKey(clientSessKey); err != nil {
+			s.logger.WarnContext(s.ctx, "AUTH Phase 2: failed to derive combined key for empty-password path",
+				slog.Any("error", err))
+		}
+
 		apiKey, err := s.store.GetAPIKeyByID(s.ctx, verifier.apiKeyID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load API key by ID: %w", err)


### PR DESCRIPTION
## Summary

The AUTH_SVR_RESPONSE patcher silently skipped for the empty-AUTH_PASSWORD branch (SQLcl / JDBC thin 23c+ where the client doesn't send a plaintext password). DecryptPassword wasn't running so \`o5.CombinedKey\` stayed nil; the upstream's AUTH OK was forwarded verbatim, and clients couldn't decrypt AUTH_SVR_RESPONSE under their own combined key.

Adds \`O5LogonServer.DeriveCombinedKey\` that performs the same client-key decrypt + combined-key candidate selection as DecryptPassword without password verification, and calls it from the empty-password branch.

This doesn't fully unblock SQLcl 26.1 (which currently sends a non-empty AUTH_PASSWORD anyway, going through DecryptPassword's existing combined-key set). It removes a silent failure mode for clients on the empty-AUTH_PASSWORD path.

## Test plan

- [x] Existing oracle unit tests pass
- [x] go-ora end-to-end still works through dbbat (verified locally)
- [ ] python-oracledb end-to-end still works (no regression — uses non-empty AUTH_PASSWORD path)