### PR TITLE
fix(oracle): trim AUTH challenge end-marker to 33 bytes — SQLcl 26.1 now works end-to-end

### DIFF
--- a/internal/proxy/oracle/ttc_auth.go
+++ b/internal/proxy/oracle/ttc_auth.go
@@ -218,25 +218,28 @@ func buildAuthChallenge(encServerSessKey, authVfrData, pbkdf2ChkSaltHex string, 
 	return buf
 }
 
-// buildAuthChallengeEndMarker builds the end-of-response (message code 4) that
-// must follow the AUTH challenge. Clients read message codes in a loop and exit
-// on code 4. This is sent as part of the same TNS Data packet or as a separate one.
-// The bytes after code 4 are a minimal Summary structure captured from Oracle 19c.
+// buildAuthChallengeEndMarker builds the end-of-response (message code 4)
+// that must follow the AUTH challenge. The Summary structure is captured from
+// a real Oracle 19c Phase 1 challenge response — exactly 32 bytes after the
+// 0x04 code byte (33 bytes total).
+//
+// Earlier versions emitted 256 zero-padded bytes "to be safe", but JDBC thin
+// (SQLcl 26.1+) parses a fixed-size Summary off the wire and leaves the
+// remaining bytes in its read buffer. On the next round-trip those leftover
+// 0x00 bytes are read as TTC message codes — code 0 isn't a valid case in
+// T4CTTIfun.receive's switch, so JDBC throws ORA-17401 with no useful
+// stack location below T4CTTIfun.receive:1048. Matching Oracle's exact
+// 33-byte tail keeps JDBC's buffer empty after the challenge.
+//
+// go-ora and python-oracledb thin happen to consume more bytes from the
+// trailing zeros (their parsers are tolerant) so they survived this bug
+// for ~2 years. The fix is also a cleanup — sending fewer bytes per challenge.
 func buildAuthChallengeEndMarker() []byte {
-	// Message code 4 + minimal summary fields that NewSummary reads.
-	// These must align with the TTC capabilities negotiated in Set Protocol.
-	// Captured from the AUTH challenge tail of Oracle 19c.
-	// Message code 4 (end of call) + minimal Summary structure.
-	// All fields are zero (compressed int = 0x00), which is safe for any TTC version/capability combo.
-	// We send 64 zero bytes after code 4 to ensure NewSummary has enough data regardless
-	// of which conditional fields are enabled.
-	buf := make([]byte, 256)
-	buf[0] = 0x04 // message code 4
-	// Remaining 255 zero bytes provide enough data for NewSummary to read
-	// all conditional fields (RetCode, CurRowNumber, Flags, error messages, etc.)
-	// regardless of TTC version and capability flags.
-
-	return buf
+	return []byte{
+		0x04,                                                                                           // end-of-call code
+		0x01, 0x01, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Summary fields
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
 }
 
 // buildAuthOK constructs the TTC AUTH success response.


### PR DESCRIPTION
## Summary

**This is the actual root cause of SQLcl ORA-17401.** dbbat's \`buildAuthChallengeEndMarker\` was emitting 256 zero-padded bytes after the 0x04 end-of-call code in the AUTH Phase 1 challenge response. JDBC thin parses a fixed-size Summary struct (32 bytes) and leaves the unread bytes in its read buffer. On the next round-trip (after sending Phase 2) JDBC's \`T4CTTIfun.receive\` reads the next byte as a TTC message code — code \`0x00\` isn't a case in the switch, so it throws ORA-17401 from the default-case handler at line 1048.

go-ora and python-oracledb thin survived this bug because their Summary parsers are tolerant — they consume more bytes from the trailing zeros. JDBC's strict parser caught it.

## Fix

Replaced the 256-byte padded buffer with the exact 33-byte tail Oracle 19c sends (1 code byte + 32-byte Summary structure), captured via tcpsniff against \`oracle-abynonprod.db.stonal.io:1521\`.

## Verification

End-to-end against real Stonal nonprod Oracle 19c via VPN:

\`\`\`
$ sql -S connector/dbb_connector_key@localhost:1523/abynonprod
SQL> SELECT 1 AS one FROM dual;
   ONE
______
     1

SQL> SELECT banner FROM v\$version WHERE rownum=1;
BANNER
_________________________________________________________________________
Oracle Database 19c Standard Edition 2 Release 19.0.0.0.0 - Production
\`\`\`

This unblocks the multi-iteration SQLcl investigation that started with PR #136 (parser regressions), continued through #138 (Phase 1 forwarding), #143 (customHash O5LOGON server), #144 (Phase 2 forwarding), and #148 (combined-key for empty-AUTH_PASSWORD). All those changes were necessary; this last byte-count fix is what JDBC needed.

## Test plan

- [x] All 256 oracle unit tests pass
- [x] SQLcl 26.1 connects + queries Oracle 19c through dbbat
- [x] go-ora end-to-end still works
- [ ] python-oracledb end-to-end (no regression — its parser was already tolerant)