### PR TITLE
feat(proxy): PostgreSQL upstream TLS and SCRAM-SHA-256 auth

### DIFF
--- a/internal/proxy/postgresql/errors.go
+++ b/internal/proxy/postgresql/errors.go
@@ -16,14 +16,26 @@ var (
 	ErrDDLNotPermitted  = errors.New("DDL operations not permitted: your access grant blocks schema modifications")
 	ErrCopyNotPermitted = errors.New("COPY not permitted: your access grant blocks COPY commands")
 
-	ErrSASLAuthNotSupported = errors.New("SASL authentication not yet supported")
-	ErrUpstreamAuthFailed   = errors.New("upstream authentication failed")
-	ErrAPIKeyOwnerMismatch  = errors.New("API key does not belong to user")
-	ErrAPIKeyVerifyFailed   = errors.New("API key verification failed")
+	ErrUpstreamAuthFailed  = errors.New("upstream authentication failed")
+	ErrAPIKeyOwnerMismatch = errors.New("API key does not belong to user")
+	ErrAPIKeyVerifyFailed  = errors.New("API key verification failed")
 
 	// Startup negotiation errors. SSL/GSS encryption probes are length-8
 	// frames with a magic version code; anything else of that shape is
 	// rejected, and runaway clients are bounded by the round limit.
 	ErrUnknownStartupMagic      = errors.New("unknown length-8 startup magic")
 	ErrTooManyNegotiationRounds = errors.New("too many SSL/GSS negotiation rounds")
+
+	// Upstream TLS errors raised when negotiating SSL with the target
+	// Postgres server (see negotiateUpstreamSSL).
+	ErrUpstreamTLSRequired = errors.New("upstream rejected TLS but ssl_mode requires it")
+	ErrUpstreamSSLResponse = errors.New("unexpected upstream SSL response byte")
+
+	// Upstream SCRAM/SASL errors raised when authenticating with the target
+	// Postgres server using SCRAM-SHA-256.
+	ErrSCRAMNoSupportedMechanism = errors.New("upstream offered no SCRAM mechanism we support")
+	ErrSCRAMServerNonceMismatch  = errors.New("SCRAM server nonce did not extend client nonce")
+	ErrSCRAMServerSignature      = errors.New("SCRAM server signature mismatch")
+	ErrSCRAMUnexpectedMessage    = errors.New("unexpected SASL message from upstream")
+	ErrSCRAMMalformedMessage     = errors.New("malformed SCRAM message from upstream")
 )

--- a/internal/proxy/postgresql/session.go
+++ b/internal/proxy/postgresql/session.go
@@ -94,6 +94,7 @@ type Session struct {
 	extendedState          *extendedQueryState         // State for Extended Query Protocol
 	clientApplicationName  string                      // application_name provided by the client
 	copyState              *copyState                  // Track COPY operation in progress
+	upstreamSCRAM          *scramClient                // SCRAM-SHA-256 state for upstream SASL auth
 }
 
 // NewSession creates a new session.

--- a/internal/proxy/postgresql/upstream.go
+++ b/internal/proxy/postgresql/upstream.go
@@ -32,6 +32,16 @@ func (s *Session) connectUpstream() error {
 		return fmt.Errorf("failed to connect to upstream: %w", err)
 	}
 
+	// Negotiate TLS with the upstream per ssl_mode (libpq semantics). Must
+	// happen before any StartupMessage — Postgres expects the SSLRequest
+	// preamble on a fresh connection, not interleaved with protocol traffic.
+	upgraded, err := negotiateUpstreamSSL(s.ctx, conn, s.database.Host, s.database.SSLMode)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("upstream SSL negotiation: %w", err)
+	}
+	conn = upgraded
+
 	s.upstreamConn = conn
 
 	// Create frontend for upstream (we act as client to upstream)
@@ -141,7 +151,13 @@ func (s *Session) processUpstreamAuthMessage(
 		return false, nil
 
 	case *pgproto3.AuthenticationSASL:
-		return false, ErrSASLAuthNotSupported
+		return false, s.beginUpstreamSCRAM(typedMsg, upstreamFrontend)
+
+	case *pgproto3.AuthenticationSASLContinue:
+		return false, s.continueUpstreamSCRAM(typedMsg, upstreamFrontend)
+
+	case *pgproto3.AuthenticationSASLFinal:
+		return false, s.finalizeUpstreamSCRAM(typedMsg)
 
 	case *pgproto3.ParameterStatus:
 		// Buffer ParameterStatus messages - they must come after AuthenticationOk
@@ -221,6 +237,69 @@ func (s *Session) processUpstreamAuthMessage(
 
 		return false, nil
 	}
+}
+
+// beginUpstreamSCRAM handles the AuthenticationSASL message: it picks a
+// supported mechanism, builds the client first message, and sends a
+// SASLInitialResponse upstream. The SCRAM state is parked on the session
+// until the matching Continue/Final messages arrive.
+func (s *Session) beginUpstreamSCRAM(
+	msg *pgproto3.AuthenticationSASL,
+	upstreamFrontend *pgproto3.Frontend,
+) error {
+	mech := pickSCRAMMechanism(msg.AuthMechanisms)
+	if mech == "" {
+		return fmt.Errorf("%w: offered=%v", ErrSCRAMNoSupportedMechanism, msg.AuthMechanisms)
+	}
+
+	client, err := newSCRAMClient(s.database.Password)
+	if err != nil {
+		return fmt.Errorf("scram client: %w", err)
+	}
+	s.upstreamSCRAM = client
+
+	resp := &pgproto3.SASLInitialResponse{
+		AuthMechanism: mech,
+		Data:          client.firstMessage(),
+	}
+	if err := sendToUpstream(upstreamFrontend, resp); err != nil {
+		return fmt.Errorf("send SASLInitialResponse: %w", err)
+	}
+	return nil
+}
+
+// continueUpstreamSCRAM handles the AuthenticationSASLContinue (server first
+// message): compute the client proof and send the SASLResponse.
+func (s *Session) continueUpstreamSCRAM(
+	msg *pgproto3.AuthenticationSASLContinue,
+	upstreamFrontend *pgproto3.Frontend,
+) error {
+	if s.upstreamSCRAM == nil {
+		return fmt.Errorf("%w: SASLContinue without SASL", ErrSCRAMUnexpectedMessage)
+	}
+	final, err := s.upstreamSCRAM.finalMessage(msg.Data)
+	if err != nil {
+		return err
+	}
+	if err := sendToUpstream(upstreamFrontend, &pgproto3.SASLResponse{Data: final}); err != nil {
+		return fmt.Errorf("send SASLResponse: %w", err)
+	}
+	return nil
+}
+
+// finalizeUpstreamSCRAM handles AuthenticationSASLFinal: verify the server's
+// signature so we know the upstream actually possesses the password's
+// SaltedPassword, then wait for the upstream's AuthenticationOk on the next
+// loop iteration.
+func (s *Session) finalizeUpstreamSCRAM(msg *pgproto3.AuthenticationSASLFinal) error {
+	if s.upstreamSCRAM == nil {
+		return fmt.Errorf("%w: SASLFinal without SASL", ErrSCRAMUnexpectedMessage)
+	}
+	if err := s.upstreamSCRAM.verifyServerFinal(msg.Data); err != nil {
+		return err
+	}
+	s.upstreamSCRAM = nil
+	return nil
 }
 
 // computeMD5Password computes the PostgreSQL MD5 password hash.

--- a/internal/proxy/postgresql/upstream_scram.go
+++ b/internal/proxy/postgresql/upstream_scram.go
@@ -1,0 +1,209 @@
+package postgresql
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// scramMechanism is the SASL mechanism dbbat speaks to upstream Postgres.
+//
+// SCRAM-SHA-256-PLUS (channel binding) is intentionally NOT supported here:
+// the client first message would need to embed a hash of the upstream TLS
+// certificate, and we accept any cert in `prefer`/`require` modes — embedding
+// the cert hash would convert ssl_mode=require's "encrypt only" guarantee
+// into a stronger one without the user opting in. Servers offering only
+// SCRAM-SHA-256-PLUS will fail upstream auth with ErrSCRAMNoSupportedMechanism.
+const scramMechanism = "SCRAM-SHA-256"
+
+// scramGS2HeaderNoBinding is the GS2 header used for plain SCRAM-SHA-256:
+// "n,," means "client doesn't support channel binding". Its base64 encoding
+// "biws" is reused as the channel-binding field of the client final message.
+const (
+	scramGS2HeaderNoBinding = "n,,"
+	scramCBindB64           = "biws" // base64("n,,")
+)
+
+// scramClient is a SCRAM-SHA-256 client state machine. It produces the two
+// outbound payloads (initial response and final message) and validates the
+// server's final signature. Two-step usage:
+//
+//	c, err := newSCRAMClient(password)
+//	first := c.firstMessage()                   // send in SASLInitialResponse
+//	final, err := c.finalMessage(serverFirst)   // send in SASLResponse
+//	err = c.verifyServerFinal(serverFinal)      // validate after AuthenticationSASLFinal
+type scramClient struct {
+	password    string
+	clientNonce string
+
+	// Persisted between messages; needed to compute AuthMessage on the
+	// client final message and to verify the server signature.
+	clientFirstBare    string
+	serverFirstMessage string
+	clientFinalNoProof string
+	saltedPassword     []byte
+}
+
+func newSCRAMClient(password string) (*scramClient, error) {
+	nonce := make([]byte, 18) // 24 base64 chars, plenty of entropy.
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("scram nonce: %w", err)
+	}
+	return &scramClient{
+		password:    password,
+		clientNonce: base64.StdEncoding.EncodeToString(nonce),
+	}, nil
+}
+
+// firstMessage returns the bytes for SASLInitialResponse.Data. PostgreSQL
+// expects the username field empty here — the upstream already has it from
+// the StartupMessage.
+func (c *scramClient) firstMessage() []byte {
+	c.clientFirstBare = "n=,r=" + c.clientNonce
+	return []byte(scramGS2HeaderNoBinding + c.clientFirstBare)
+}
+
+// finalMessage parses the server's first message and returns the bytes for
+// SASLResponse.Data (the client final message with proof).
+func (c *scramClient) finalMessage(serverFirst []byte) ([]byte, error) {
+	c.serverFirstMessage = string(serverFirst)
+
+	combinedNonce, salt, iter, err := parseSCRAMServerFirst(c.serverFirstMessage)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(combinedNonce, c.clientNonce) {
+		return nil, ErrSCRAMServerNonceMismatch
+	}
+
+	c.saltedPassword = pbkdf2.Key([]byte(c.password), salt, iter, sha256.Size, sha256.New)
+
+	clientKey := hmacSHA256(c.saltedPassword, []byte("Client Key"))
+	storedKey := sha256Sum(clientKey)
+
+	c.clientFinalNoProof = "c=" + scramCBindB64 + ",r=" + combinedNonce
+	authMessage := c.clientFirstBare + "," + c.serverFirstMessage + "," + c.clientFinalNoProof
+
+	clientSignature := hmacSHA256(storedKey, []byte(authMessage))
+	clientProof := xorBytes(clientKey, clientSignature)
+
+	return []byte(c.clientFinalNoProof + ",p=" + base64.StdEncoding.EncodeToString(clientProof)), nil
+}
+
+// verifyServerFinal checks that the server's final message contains a
+// signature derived from the same shared secret. PostgreSQL won't progress
+// past AuthenticationSASLFinal unless this passes, but we still verify
+// locally — a malicious upstream could otherwise complete auth with garbage.
+func (c *scramClient) verifyServerFinal(serverFinal []byte) error {
+	v, err := parseSCRAMServerFinal(string(serverFinal))
+	if err != nil {
+		return err
+	}
+
+	serverKey := hmacSHA256(c.saltedPassword, []byte("Server Key"))
+	authMessage := c.clientFirstBare + "," + c.serverFirstMessage + "," + c.clientFinalNoProof
+	expected := hmacSHA256(serverKey, []byte(authMessage))
+
+	got, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return fmt.Errorf("%w: server signature: %w", ErrSCRAMMalformedMessage, err)
+	}
+	if !hmac.Equal(got, expected) {
+		return ErrSCRAMServerSignature
+	}
+	return nil
+}
+
+// parseSCRAMServerFirst extracts r=, s=, i= from `r=...,s=...,i=...`. Order
+// is fixed by RFC 5802 §5.1 ("nonce", "salt", "iteration-count").
+func parseSCRAMServerFirst(s string) (string, []byte, int, error) {
+	fields := splitSCRAMFields(s)
+	r, ok := fields["r"]
+	if !ok {
+		return "", nil, 0, fmt.Errorf("%w: missing r= in server first", ErrSCRAMMalformedMessage)
+	}
+	saltB64, ok := fields["s"]
+	if !ok {
+		return "", nil, 0, fmt.Errorf("%w: missing s= in server first", ErrSCRAMMalformedMessage)
+	}
+	iStr, ok := fields["i"]
+	if !ok {
+		return "", nil, 0, fmt.Errorf("%w: missing i= in server first", ErrSCRAMMalformedMessage)
+	}
+	salt, err := base64.StdEncoding.DecodeString(saltB64)
+	if err != nil {
+		return "", nil, 0, fmt.Errorf("%w: salt b64: %w", ErrSCRAMMalformedMessage, err)
+	}
+	iter, err := strconv.Atoi(iStr)
+	if err != nil {
+		return "", nil, 0, fmt.Errorf("%w: iteration count: %w", ErrSCRAMMalformedMessage, err)
+	}
+	return r, salt, iter, nil
+}
+
+// parseSCRAMServerFinal returns the v= value, or the e= error if the server
+// rejected auth (§7 server-final-message). Either form is well-formed; the
+// caller treats e= as ErrSCRAMServerSignature's failure mode at a higher level.
+func parseSCRAMServerFinal(s string) (string, error) {
+	fields := splitSCRAMFields(s)
+	if e, ok := fields["e"]; ok {
+		return "", fmt.Errorf("%w: server reported %q", ErrSCRAMServerSignature, e)
+	}
+	v, ok := fields["v"]
+	if !ok {
+		return "", fmt.Errorf("%w: missing v= in server final", ErrSCRAMMalformedMessage)
+	}
+	return v, nil
+}
+
+// splitSCRAMFields parses a comma-separated `key=value` list. The value half
+// may itself contain '=' (base64), so split only on the first.
+func splitSCRAMFields(s string) map[string]string {
+	out := make(map[string]string)
+	for _, part := range strings.Split(s, ",") {
+		eq := strings.IndexByte(part, '=')
+		if eq <= 0 {
+			continue
+		}
+		out[part[:eq]] = part[eq+1:]
+	}
+	return out
+}
+
+func hmacSHA256(key, msg []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(msg)
+	return h.Sum(nil)
+}
+
+func sha256Sum(b []byte) []byte {
+	sum := sha256.Sum256(b)
+	return sum[:]
+}
+
+func xorBytes(a, b []byte) []byte {
+	out := make([]byte, len(a))
+	for i := range a {
+		out[i] = a[i] ^ b[i]
+	}
+	return out
+}
+
+// pickSCRAMMechanism returns scramMechanism if the upstream offered it, or
+// the empty string otherwise. The pgproto3 AuthenticationSASL message gives
+// us the list as a NUL-terminated array; pgproto3 already strips the NULs
+// and gives us a []string.
+func pickSCRAMMechanism(offered []string) string {
+	for _, m := range offered {
+		if m == scramMechanism {
+			return m
+		}
+	}
+	return ""
+}

--- a/internal/proxy/postgresql/upstream_scram_test.go
+++ b/internal/proxy/postgresql/upstream_scram_test.go
@@ -1,0 +1,131 @@
+package postgresql
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// RFC 7677 §3 SCRAM-SHA-256 example. Username "user" / password "pencil".
+// We exercise the math by injecting the same nonces the RFC uses; the
+// expected proof and server signature come straight from the RFC.
+const (
+	rfcClientNonce  = "rOprNGfwEbeRWgbNEkqO"
+	rfcServerFirst  = "r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096"
+	rfcExpectedFin  = "c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ="
+	rfcServerFinal  = "v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4="
+	rfcWrongVerify  = "v=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	rfcServerErrMsg = "e=invalid-proof"
+)
+
+// rfcClient constructs a scramClient with the deterministic nonce and the
+// RFC's username-bearing client first message ("n=user", not the empty
+// username PostgreSQL uses). The math under test is identical either way —
+// only the AuthMessage prefix differs.
+func rfcClient(t *testing.T) *scramClient {
+	t.Helper()
+	return &scramClient{
+		password:        "pencil",
+		clientNonce:     rfcClientNonce,
+		clientFirstBare: "n=user,r=" + rfcClientNonce,
+	}
+}
+
+func TestSCRAMClient_FirstMessageHasEmptyUsername(t *testing.T) {
+	t.Parallel()
+
+	c, err := newSCRAMClient("pencil")
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	got := string(c.firstMessage())
+	if !strings.HasPrefix(got, "n,,n=,r=") {
+		t.Fatalf("firstMessage: got %q, want prefix %q", got, "n,,n=,r=")
+	}
+}
+
+func TestSCRAMClient_FinalMessageMatchesRFC(t *testing.T) {
+	t.Parallel()
+
+	c := rfcClient(t)
+	got, err := c.finalMessage([]byte(rfcServerFirst))
+	if err != nil {
+		t.Fatalf("finalMessage: %v", err)
+	}
+	if string(got) != rfcExpectedFin {
+		t.Fatalf("finalMessage:\n got  %s\n want %s", got, rfcExpectedFin)
+	}
+}
+
+func TestSCRAMClient_VerifyServerFinalAcceptsRFCSignature(t *testing.T) {
+	t.Parallel()
+
+	c := rfcClient(t)
+	if _, err := c.finalMessage([]byte(rfcServerFirst)); err != nil {
+		t.Fatalf("final: %v", err)
+	}
+	if err := c.verifyServerFinal([]byte(rfcServerFinal)); err != nil {
+		t.Fatalf("verifyServerFinal: %v", err)
+	}
+}
+
+func TestSCRAMClient_VerifyServerFinalRejectsWrongSignature(t *testing.T) {
+	t.Parallel()
+
+	c := rfcClient(t)
+	if _, err := c.finalMessage([]byte(rfcServerFirst)); err != nil {
+		t.Fatalf("final: %v", err)
+	}
+	err := c.verifyServerFinal([]byte(rfcWrongVerify))
+	if !errors.Is(err, ErrSCRAMServerSignature) {
+		t.Fatalf("expected ErrSCRAMServerSignature, got %v", err)
+	}
+}
+
+func TestSCRAMClient_VerifyServerFinalSurfacesServerError(t *testing.T) {
+	t.Parallel()
+
+	c := rfcClient(t)
+	if _, err := c.finalMessage([]byte(rfcServerFirst)); err != nil {
+		t.Fatalf("final: %v", err)
+	}
+	err := c.verifyServerFinal([]byte(rfcServerErrMsg))
+	if !errors.Is(err, ErrSCRAMServerSignature) {
+		t.Fatalf("expected ErrSCRAMServerSignature for server-reported error, got %v", err)
+	}
+}
+
+func TestSCRAMClient_RejectsServerNonceMismatch(t *testing.T) {
+	t.Parallel()
+
+	c := rfcClient(t)
+	bad := "r=DIFFERENTNONCE,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096"
+	_, err := c.finalMessage([]byte(bad))
+	if !errors.Is(err, ErrSCRAMServerNonceMismatch) {
+		t.Fatalf("expected ErrSCRAMServerNonceMismatch, got %v", err)
+	}
+}
+
+func TestSCRAMClient_RejectsMalformedServerFirst(t *testing.T) {
+	t.Parallel()
+
+	c := rfcClient(t)
+	_, err := c.finalMessage([]byte("garbage,no,fields"))
+	if !errors.Is(err, ErrSCRAMMalformedMessage) {
+		t.Fatalf("expected ErrSCRAMMalformedMessage, got %v", err)
+	}
+}
+
+func TestPickSCRAMMechanism(t *testing.T) {
+	t.Parallel()
+
+	got := pickSCRAMMechanism([]string{"SCRAM-SHA-256-PLUS", "SCRAM-SHA-256"})
+	if got != "SCRAM-SHA-256" {
+		t.Fatalf("pickSCRAMMechanism: got %q, want SCRAM-SHA-256", got)
+	}
+
+	got = pickSCRAMMechanism([]string{"SCRAM-SHA-256-PLUS"})
+	if got != "" {
+		t.Fatalf("pickSCRAMMechanism: PLUS-only should return empty, got %q", got)
+	}
+}

--- a/internal/proxy/postgresql/upstream_tls.go
+++ b/internal/proxy/postgresql/upstream_tls.go
@@ -1,0 +1,90 @@
+package postgresql
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+// upstreamSSLRequest is the 8-byte SSLRequest preamble (length=8, magic
+// pgSSLRequestCode) sent before the StartupMessage to probe a Postgres server
+// for TLS support.
+var upstreamSSLRequest = func() []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint32(buf[0:4], 8)
+	binary.BigEndian.PutUint32(buf[4:8], pgSSLRequestCode)
+	return buf
+}()
+
+// negotiateUpstreamSSL probes the upstream Postgres for TLS and either
+// upgrades the connection, falls back to plaintext, or fails based on
+// ssl_mode. Mirrors libpq sslmode semantics:
+//
+//   - disable:                  plaintext only, no probe sent.
+//   - allow / prefer / "":      probe; on 'S' upgrade with cert verification
+//     skipped, on 'N' continue plaintext.
+//   - require:                  probe; on 'S' upgrade with cert verification
+//     skipped, on 'N' fail.
+//   - verify-ca / verify-full:  probe; on 'S' upgrade with full cert + hostname
+//     verification, on 'N' fail. (Go stdlib doesn't cleanly express
+//     "verify CA but not hostname", so verify-ca is treated as verify-full —
+//     stricter than libpq, but safer.)
+//
+// On error the original conn is left open; the caller is responsible for
+// closing it.
+func negotiateUpstreamSSL(ctx context.Context, conn net.Conn, host, mode string) (net.Conn, error) {
+	if mode == "disable" {
+		return conn, nil
+	}
+
+	if _, err := conn.Write(upstreamSSLRequest); err != nil {
+		return nil, fmt.Errorf("send SSLRequest: %w", err)
+	}
+
+	resp := make([]byte, 1)
+	if _, err := conn.Read(resp); err != nil {
+		return nil, fmt.Errorf("read SSL response: %w", err)
+	}
+
+	switch resp[0] {
+	case 'S':
+		tlsConn := tls.Client(conn, upstreamTLSConfig(host, mode))
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			return nil, fmt.Errorf("upstream TLS handshake: %w", err)
+		}
+		return tlsConn, nil
+	case 'N':
+		if upstreamTLSRequired(mode) {
+			return nil, fmt.Errorf("%w: ssl_mode=%s", ErrUpstreamTLSRequired, mode)
+		}
+		return conn, nil
+	default:
+		return nil, fmt.Errorf("%w: 0x%02x", ErrUpstreamSSLResponse, resp[0])
+	}
+}
+
+// upstreamTLSRequired reports whether the ssl_mode forbids plaintext fallback.
+func upstreamTLSRequired(mode string) bool {
+	switch mode {
+	case "require", "verify-ca", "verify-full":
+		return true
+	}
+	return false
+}
+
+// upstreamTLSConfig builds a tls.Config for an upstream connection at the
+// given ssl_mode. verify-ca/verify-full both verify the cert chain and the
+// hostname (see negotiateUpstreamSSL doc); other modes accept any cert.
+func upstreamTLSConfig(host, mode string) *tls.Config {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	switch mode {
+	case "verify-ca", "verify-full":
+		cfg.ServerName = host
+	default:
+		// require/prefer parity with libpq: encrypt without authenticating the server.
+		cfg.InsecureSkipVerify = true
+	}
+	return cfg
+}

--- a/internal/proxy/postgresql/upstream_tls_test.go
+++ b/internal/proxy/postgresql/upstream_tls_test.go
@@ -1,0 +1,190 @@
+package postgresql
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+var errSSLRequestMismatch = errors.New("SSLRequest preamble mismatch")
+
+// readSSLRequest reads the 8-byte SSLRequest preamble from c and returns an
+// error if it doesn't match what negotiateUpstreamSSL is expected to send.
+func readSSLRequest(c net.Conn) error {
+	got := make([]byte, 8)
+	if _, err := io.ReadFull(c, got); err != nil {
+		return err
+	}
+	for i := range got {
+		if got[i] != upstreamSSLRequest[i] {
+			return errSSLRequestMismatch
+		}
+	}
+	return nil
+}
+
+func TestNegotiateUpstreamSSL_DisableSkipsProbe(t *testing.T) {
+	t.Parallel()
+
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
+
+	// Server reads nothing; if anything is sent, the test will hang and
+	// time out. Use a short read with deadline to assert silence.
+	probe := make(chan error, 1)
+	go func() {
+		_ = serverSide.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+		buf := make([]byte, 1)
+		_, err := serverSide.Read(buf)
+		probe <- err
+	}()
+
+	out, err := negotiateUpstreamSSL(context.Background(), clientSide, "example.com", "disable")
+	if err != nil {
+		t.Fatalf("disable: unexpected error: %v", err)
+	}
+	if out != clientSide {
+		t.Fatalf("disable: expected original conn returned, got different conn")
+	}
+
+	if err := <-probe; err == nil {
+		t.Fatalf("disable: server received bytes, expected none")
+	}
+}
+
+func TestNegotiateUpstreamSSL_PreferFallsBackToPlaintext(t *testing.T) {
+	t.Parallel()
+
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
+
+	go func() {
+		if err := readSSLRequest(serverSide); err != nil {
+			return
+		}
+		_, _ = serverSide.Write([]byte{'N'})
+	}()
+
+	out, err := negotiateUpstreamSSL(context.Background(), clientSide, "example.com", "prefer")
+	if err != nil {
+		t.Fatalf("prefer + N: unexpected error: %v", err)
+	}
+	if out != clientSide {
+		t.Fatalf("prefer + N: expected plain conn passthrough")
+	}
+}
+
+func TestNegotiateUpstreamSSL_RequireFailsOnDeny(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []string{"require", "verify-ca", "verify-full"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+
+			clientSide, serverSide := net.Pipe()
+			defer func() { _ = clientSide.Close() }()
+			defer func() { _ = serverSide.Close() }()
+
+			go func() {
+				if err := readSSLRequest(serverSide); err != nil {
+					return
+				}
+				_, _ = serverSide.Write([]byte{'N'})
+			}()
+
+			_, err := negotiateUpstreamSSL(context.Background(), clientSide, "example.com", mode)
+			if !errors.Is(err, ErrUpstreamTLSRequired) {
+				t.Fatalf("%s + N: expected ErrUpstreamTLSRequired, got %v", mode, err)
+			}
+		})
+	}
+}
+
+func TestNegotiateUpstreamSSL_UnexpectedResponseByte(t *testing.T) {
+	t.Parallel()
+
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	defer func() { _ = serverSide.Close() }()
+
+	go func() {
+		if err := readSSLRequest(serverSide); err != nil {
+			return
+		}
+		_, _ = serverSide.Write([]byte{'X'})
+	}()
+
+	_, err := negotiateUpstreamSSL(context.Background(), clientSide, "example.com", "prefer")
+	if !errors.Is(err, ErrUpstreamSSLResponse) {
+		t.Fatalf("expected ErrUpstreamSSLResponse, got %v", err)
+	}
+}
+
+func TestNegotiateUpstreamSSL_AcceptUpgradesToTLS(t *testing.T) {
+	t.Parallel()
+
+	tlsConf, err := generateSelfSignedTLS()
+	if err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer func() { _ = serverSide.Close() }()
+		if err := readSSLRequest(serverSide); err != nil {
+			serverErr <- err
+			return
+		}
+		if _, err := serverSide.Write([]byte{'S'}); err != nil {
+			serverErr <- err
+			return
+		}
+		tlsConn := tls.Server(serverSide, tlsConf)
+		serverErr <- tlsConn.Handshake()
+	}()
+
+	out, err := negotiateUpstreamSSL(context.Background(), clientSide, "example.com", "require")
+	if err != nil {
+		t.Fatalf("require + S: handshake failed: %v", err)
+	}
+	if _, ok := out.(*tls.Conn); !ok {
+		t.Fatalf("require + S: expected *tls.Conn, got %T", out)
+	}
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			t.Fatalf("server side: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server handshake hung")
+	}
+}
+
+func TestUpstreamTLSConfig_ServerNameSetForVerifyModes(t *testing.T) {
+	t.Parallel()
+
+	cfg := upstreamTLSConfig("example.com", "verify-full")
+	if cfg.ServerName != "example.com" || cfg.InsecureSkipVerify {
+		t.Fatalf("verify-full: ServerName=%q InsecureSkipVerify=%v", cfg.ServerName, cfg.InsecureSkipVerify)
+	}
+
+	cfg = upstreamTLSConfig("example.com", "verify-ca")
+	if cfg.ServerName != "example.com" || cfg.InsecureSkipVerify {
+		t.Fatalf("verify-ca: ServerName=%q InsecureSkipVerify=%v", cfg.ServerName, cfg.InsecureSkipVerify)
+	}
+
+	cfg = upstreamTLSConfig("example.com", "require")
+	if !cfg.InsecureSkipVerify {
+		t.Fatalf("require: expected InsecureSkipVerify=true")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the gap left by #131 (client-side TLS termination): the PostgreSQL proxy now negotiates TLS with the upstream **and** authenticates with SCRAM-SHA-256, so it can target managed Postgres instances that require SSL and reject MD5 (modern RDS, Aurora, Cloud SQL).

Both pieces are needed together — the symptom on a fresh RDS instance was first `no pg_hba.conf entry … no encryption`, then once TLS worked, `SASL authentication not yet supported`.

## What's in here

- **Upstream TLS** (`upstream_tls.go`) — libpq semantics for `ssl_mode`: `disable` / `prefer` (default) / `require` / `verify-ca` / `verify-full`. The proxy sends `SSLRequest` before `StartupMessage`; on `'S'` wraps the conn in `tls.Client`, on `'N'` `prefer` falls back to plaintext while `require`/`verify-*` fail. `verify-ca` is treated as `verify-full` (Go stdlib doesn't cleanly express CA-only verification — stricter than libpq, safer default).
- **SCRAM-SHA-256** (`upstream_scram.go`) — RFC 5802 / 7677 client. PBKDF2-HMAC-SHA-256 over the password, `ClientProof = ClientKey XOR HMAC(StoredKey, AuthMessage)`, server signature verified on `AuthenticationSASLFinal` so a malicious upstream can't fake auth-success. `SCRAM-SHA-256-PLUS` (channel binding) intentionally **not** supported — embedding a cert hash would silently strengthen `ssl_mode=require`'s "encrypt only" guarantee without the user opting in.
- Wired into `processUpstreamAuthMessage` via three new cases (`AuthenticationSASL` / `AuthenticationSASLContinue` / `AuthenticationSASLFinal`); the now-dead `ErrSASLAuthNotSupported` is removed.

## Test plan

- [x] `go test ./...` — 971 pass, including 14 new tests
- [x] `make lint` — clean
- [x] TLS negotiation paths: disable skip, prefer fallback on `'N'`, require rejection (require/verify-ca/verify-full), unexpected response byte, real-handshake round-trip
- [x] SCRAM math validated against RFC 7677's published vectors (proof and server signature)
- [x] End-to-end against a Postgres 18.1 RDS instance with `scram-sha-256` `pg_hba.conf` and TLS enforced — `SELECT current_database(), current_user, version();` returns the expected row through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)