### PR TITLE
fix(grants): populate query_count and bytes_transferred + UI polish

### DIFF
--- a/front/e2e/admin-password-reset.spec.ts
+++ b/front/e2e/admin-password-reset.spec.ts
@@ -237,13 +237,10 @@ test.describe("Admin Password Reset", () => {
       await page.goto("/app/users");
       await page.waitForLoadState("networkidle");
 
-      // Step 5: Open actions menu for test user
-      const actionsButton = page.getByTestId(`user-actions-${testUsername}`);
-      await actionsButton.waitFor({ state: "visible", timeout: 10000 });
-      await actionsButton.click();
-
-      // Step 6: Click reset password
-      await page.getByTestId(`reset-password-${testUsername}`).click();
+      // Step 5: Click reset password directly
+      const resetButton = page.getByTestId(`reset-password-${testUsername}`);
+      await resetButton.waitFor({ state: "visible", timeout: 10000 });
+      await resetButton.click();
 
       // Step 7: Wait for dialog
       const dialog = page.getByTestId("reset-password-dialog");
@@ -310,8 +307,7 @@ test.describe("Admin Password Reset", () => {
       await page.goto("/app/users");
       await page.waitForLoadState("networkidle");
 
-      // Step 5: Open actions menu for test user
-      await page.getByTestId(`user-actions-${testUsername}`).click();
+      // Step 5: Click reset password directly
       await page.getByTestId(`reset-password-${testUsername}`).click();
 
       // Step 6: Wait for dialog

--- a/front/src/routes/_authenticated/index.tsx
+++ b/front/src/routes/_authenticated/index.tsx
@@ -121,6 +121,7 @@ function DashboardPage() {
             data={queries ?? []}
             isLoading={queriesLoading}
             rowKey={(q) => q.uid}
+            rowHref={(q) => `/queries/${q.uid}`}
             emptyMessage="No queries recorded yet"
           />
         </div>

--- a/front/src/routes/_authenticated/users/index.tsx
+++ b/front/src/routes/_authenticated/users/index.tsx
@@ -34,12 +34,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -48,7 +42,7 @@ import { ResetPasswordDialog } from "@/components/shared/ResetPasswordDialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Plus, Trash2, MoreHorizontal, KeyRound } from "lucide-react";
+import { Plus, Trash2, KeyRound } from "lucide-react";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 
@@ -109,64 +103,55 @@ function UsersPage() {
       key: "actions",
       header: "",
       cell: (u) => (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              data-testid={`user-actions-${u.username}`}
-            >
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {canReset ? (
-              <DropdownMenuItem
-                onClick={() => setResetPasswordUser(u)}
+        <div className="flex items-center justify-end gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={!canReset}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setResetPasswordUser(u);
+                }}
                 data-testid={`reset-password-${u.username}`}
+                aria-label={`Reset password for ${u.username}`}
               >
-                <KeyRound className="mr-2 h-4 w-4" />
-                Reset Password
-              </DropdownMenuItem>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuItem disabled>
-                    <KeyRound className="mr-2 h-4 w-4" />
-                    Reset Password
-                  </DropdownMenuItem>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {getDisabledReason("reset-password", user?.roles)}
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {canDelete ? (
-              <DropdownMenuItem
-                onClick={() => setDeleteUser(u)}
-                className="text-destructive focus:text-destructive"
+                <KeyRound className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {canReset
+                ? "Reset password"
+                : getDisabledReason("reset-password", user?.roles)}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={!canDelete}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setDeleteUser(u);
+                }}
+                className="text-destructive hover:text-destructive"
                 data-testid={`delete-user-${u.username}`}
+                aria-label={`Delete user ${u.username}`}
               >
-                <Trash2 className="mr-2 h-4 w-4" />
-                Delete User
-              </DropdownMenuItem>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuItem disabled>
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    Delete User
-                  </DropdownMenuItem>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {getDisabledReason("delete-user", user?.roles)}
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {canDelete
+                ? "Delete user"
+                : getDisabledReason("delete-user", user?.roles)}
+            </TooltipContent>
+          </Tooltip>
+        </div>
       ),
-      className: "w-10",
+      className: "w-20",
     },
   ];
 

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -63,25 +63,9 @@ func (s *Store) GetActiveGrant(ctx context.Context, userID, databaseID uuid.UUID
 		return nil, fmt.Errorf("failed to get active grant: %w", err)
 	}
 
-	// Get query count from queries table within the grant's time window
-	var queryCount int64
-	err = s.db.NewSelect().
-		ColumnExpr("COUNT(*) as query_count").
-		TableExpr("queries q").
-		Join("JOIN connections c ON q.connection_id = c.uid").
-		Where("c.user_id = ?", userID).
-		Where("c.database_id = ?", databaseID).
-		Where("q.executed_at >= ?", grant.StartsAt).
-		Where("q.executed_at < ?", grant.ExpiresAt).
-		Scan(ctx, &queryCount)
-	if err != nil {
-		// Non-fatal, just set to 0
-		queryCount = 0
+	if err := s.populateGrantCounters(ctx, grant); err != nil {
+		return nil, err
 	}
-
-	grant.QueryCount = queryCount
-	grant.BytesTransferred = 0 // Tracked in-session only
-
 	return grant, nil
 }
 
@@ -97,6 +81,10 @@ func (s *Store) GetGrantByUID(ctx context.Context, uid uuid.UUID) (*Grant, error
 			return nil, ErrGrantNotFound
 		}
 		return nil, fmt.Errorf("failed to get grant: %w", err)
+	}
+
+	if err := s.populateGrantCounters(ctx, grant); err != nil {
+		return nil, err
 	}
 	return grant, nil
 }
@@ -128,7 +116,53 @@ func (s *Store) ListGrants(ctx context.Context, filter GrantFilter) ([]Grant, er
 	if grants == nil {
 		grants = []AccessGrant{}
 	}
+	for i := range grants {
+		if err := s.populateGrantCounters(ctx, &grants[i]); err != nil {
+			return nil, err
+		}
+	}
 	return grants, nil
+}
+
+// populateGrantCounters fills the transient QueryCount and BytesTransferred
+// fields of g by aggregating from the queries and connections tables within
+// the grant's effective time window: [StartsAt, min(ExpiresAt, RevokedAt)).
+func (s *Store) populateGrantCounters(ctx context.Context, g *AccessGrant) error {
+	upper := g.ExpiresAt
+	if g.RevokedAt != nil && g.RevokedAt.Before(upper) {
+		upper = *g.RevokedAt
+	}
+
+	var queryCount int64
+	err := s.db.NewSelect().
+		ColumnExpr("COUNT(*)").
+		TableExpr("queries AS q").
+		Join("JOIN connections AS c ON q.connection_id = c.uid").
+		Where("c.user_id = ?", g.UserID).
+		Where("c.database_id = ?", g.DatabaseID).
+		Where("q.executed_at >= ?", g.StartsAt).
+		Where("q.executed_at < ?", upper).
+		Scan(ctx, &queryCount)
+	if err != nil {
+		return fmt.Errorf("failed to aggregate grant query count: %w", err)
+	}
+
+	var bytesTransferred int64
+	err = s.db.NewSelect().
+		ColumnExpr("COALESCE(SUM(bytes_transferred), 0)").
+		Model((*Connection)(nil)).
+		Where("user_id = ?", g.UserID).
+		Where("database_id = ?", g.DatabaseID).
+		Where("connected_at >= ?", g.StartsAt).
+		Where("connected_at < ?", upper).
+		Scan(ctx, &bytesTransferred)
+	if err != nil {
+		return fmt.Errorf("failed to aggregate grant bytes transferred: %w", err)
+	}
+
+	g.QueryCount = queryCount
+	g.BytesTransferred = bytesTransferred
+	return nil
 }
 
 // RevokeGrant revokes a grant
@@ -157,18 +191,3 @@ func (s *Store) RevokeGrant(ctx context.Context, uid uuid.UUID, revokedBy uuid.U
 	return nil
 }
 
-// IncrementQueryCount increments the query count for tracking quota usage.
-// This is called from the connections/queries tracking.
-func (s *Store) IncrementQueryCount(_ context.Context, _ uuid.UUID) error {
-	// Note: In the current schema, we don't have a query_count column on access_grants
-	// We calculate it dynamically from connections/queries
-	// This function is a placeholder for future optimization
-	return nil
-}
-
-// IncrementBytesTransferred increments the bytes transferred for tracking quota usage.
-func (s *Store) IncrementBytesTransferred(_ context.Context, _ uuid.UUID, _ int64) error {
-	// Note: Similar to IncrementQueryCount, this is calculated dynamically
-	// This function is a placeholder for future optimization
-	return nil
-}

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -190,4 +190,3 @@ func (s *Store) RevokeGrant(ctx context.Context, uid uuid.UUID, revokedBy uuid.U
 
 	return nil
 }
-

--- a/internal/store/grants_test.go
+++ b/internal/store/grants_test.go
@@ -372,24 +372,256 @@ func TestRevokeGrant(t *testing.T) {
 	})
 }
 
-func TestIncrementQueryCount(t *testing.T) {
+func TestGrantCounters_PopulatedFromQueriesAndConnections(t *testing.T) {
 	store := setupTestStore(t)
 	ctx := context.Background()
 
-	// This is a placeholder function, just verify it doesn't error
-	err := store.IncrementQueryCount(ctx, uuid.New())
+	user, database := createTestUserAndDatabase(t, ctx, store, "counters")
+	admin, _ := store.CreateUser(ctx, "countersadmin", "hash", []string{RoleAdmin, RoleConnector})
+
+	now := time.Now()
+	grant, err := store.CreateGrant(ctx, &Grant{
+		UserID:     user.UID,
+		DatabaseID: database.UID,
+		Controls:   []string{},
+		GrantedBy:  admin.UID,
+		StartsAt:   now.Add(-time.Hour),
+		ExpiresAt:  now.Add(time.Hour),
+	})
 	if err != nil {
-		t.Errorf("IncrementQueryCount() error = %v", err)
+		t.Fatalf("CreateGrant() error = %v", err)
+	}
+
+	conn, err := store.CreateConnection(ctx, user.UID, database.UID, "10.0.0.1")
+	if err != nil {
+		t.Fatalf("CreateConnection() error = %v", err)
+	}
+
+	const queryBytes = int64(100)
+	for i := 0; i < 3; i++ {
+		if _, err := store.CreateQuery(ctx, &Query{
+			ConnectionID: conn.UID,
+			SQLText:      "SELECT 1",
+			ExecutedAt:   now,
+		}); err != nil {
+			t.Fatalf("CreateQuery() error = %v", err)
+		}
+		if err := store.IncrementConnectionStats(ctx, conn.UID, queryBytes); err != nil {
+			t.Fatalf("IncrementConnectionStats() error = %v", err)
+		}
+	}
+
+	got, err := store.GetGrantByUID(ctx, grant.UID)
+	if err != nil {
+		t.Fatalf("GetGrantByUID() error = %v", err)
+	}
+	if got.QueryCount != 3 {
+		t.Errorf("QueryCount = %d, want 3", got.QueryCount)
+	}
+	if got.BytesTransferred != 3*queryBytes {
+		t.Errorf("BytesTransferred = %d, want %d", got.BytesTransferred, 3*queryBytes)
+	}
+
+	active, err := store.GetActiveGrant(ctx, user.UID, database.UID)
+	if err != nil {
+		t.Fatalf("GetActiveGrant() error = %v", err)
+	}
+	if active.QueryCount != 3 {
+		t.Errorf("active QueryCount = %d, want 3", active.QueryCount)
+	}
+	if active.BytesTransferred != 3*queryBytes {
+		t.Errorf("active BytesTransferred = %d, want %d", active.BytesTransferred, 3*queryBytes)
 	}
 }
 
-func TestIncrementBytesTransferred(t *testing.T) {
+func TestGrantCounters_TimeWindowExcludesOutOfRange(t *testing.T) {
 	store := setupTestStore(t)
 	ctx := context.Background()
 
-	// This is a placeholder function, just verify it doesn't error
-	err := store.IncrementBytesTransferred(ctx, uuid.New(), 1024)
+	user, database := createTestUserAndDatabase(t, ctx, store, "window")
+	admin, _ := store.CreateUser(ctx, "windowadmin", "hash", []string{RoleAdmin, RoleConnector})
+
+	now := time.Now()
+	// Grant window is entirely in the future relative to the activity below.
+	grant, err := store.CreateGrant(ctx, &Grant{
+		UserID:     user.UID,
+		DatabaseID: database.UID,
+		Controls:   []string{},
+		GrantedBy:  admin.UID,
+		StartsAt:   now.Add(time.Hour),
+		ExpiresAt:  now.Add(2 * time.Hour),
+	})
 	if err != nil {
-		t.Errorf("IncrementBytesTransferred() error = %v", err)
+		t.Fatalf("CreateGrant() error = %v", err)
+	}
+
+	conn, err := store.CreateConnection(ctx, user.UID, database.UID, "10.0.0.2")
+	if err != nil {
+		t.Fatalf("CreateConnection() error = %v", err)
+	}
+	if _, err := store.CreateQuery(ctx, &Query{
+		ConnectionID: conn.UID,
+		SQLText:      "SELECT 1",
+		ExecutedAt:   now,
+	}); err != nil {
+		t.Fatalf("CreateQuery() error = %v", err)
+	}
+	if err := store.IncrementConnectionStats(ctx, conn.UID, 500); err != nil {
+		t.Fatalf("IncrementConnectionStats() error = %v", err)
+	}
+
+	got, err := store.GetGrantByUID(ctx, grant.UID)
+	if err != nil {
+		t.Fatalf("GetGrantByUID() error = %v", err)
+	}
+	if got.QueryCount != 0 {
+		t.Errorf("QueryCount = %d, want 0 (activity is before grant.StartsAt)", got.QueryCount)
+	}
+	if got.BytesTransferred != 0 {
+		t.Errorf("BytesTransferred = %d, want 0 (activity is before grant.StartsAt)", got.BytesTransferred)
+	}
+}
+
+func TestGrantCounters_BoundedByRevokedAt(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	user, database := createTestUserAndDatabase(t, ctx, store, "revokebound")
+	admin, _ := store.CreateUser(ctx, "revokeboundadmin", "hash", []string{RoleAdmin, RoleConnector})
+
+	now := time.Now()
+	grant, err := store.CreateGrant(ctx, &Grant{
+		UserID:     user.UID,
+		DatabaseID: database.UID,
+		Controls:   []string{},
+		GrantedBy:  admin.UID,
+		StartsAt:   now.Add(-time.Hour),
+		ExpiresAt:  now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateGrant() error = %v", err)
+	}
+
+	// Pre-revocation activity (should be counted).
+	preConn, err := store.CreateConnection(ctx, user.UID, database.UID, "10.0.0.3")
+	if err != nil {
+		t.Fatalf("CreateConnection() error = %v", err)
+	}
+	if _, err := store.CreateQuery(ctx, &Query{
+		ConnectionID: preConn.UID,
+		SQLText:      "SELECT pre",
+		ExecutedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("CreateQuery() error = %v", err)
+	}
+	if err := store.IncrementConnectionStats(ctx, preConn.UID, 100); err != nil {
+		t.Fatalf("IncrementConnectionStats() error = %v", err)
+	}
+
+	// Ensure RevokedAt > pre-activity timestamps and < post-activity timestamps.
+	time.Sleep(20 * time.Millisecond)
+	if err := store.RevokeGrant(ctx, grant.UID, admin.UID); err != nil {
+		t.Fatalf("RevokeGrant() error = %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	// Post-revocation activity (should NOT be counted).
+	postConn, err := store.CreateConnection(ctx, user.UID, database.UID, "10.0.0.4")
+	if err != nil {
+		t.Fatalf("CreateConnection() error = %v", err)
+	}
+	if _, err := store.CreateQuery(ctx, &Query{
+		ConnectionID: postConn.UID,
+		SQLText:      "SELECT post",
+		ExecutedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("CreateQuery() error = %v", err)
+	}
+	if err := store.IncrementConnectionStats(ctx, postConn.UID, 999); err != nil {
+		t.Fatalf("IncrementConnectionStats() error = %v", err)
+	}
+
+	got, err := store.GetGrantByUID(ctx, grant.UID)
+	if err != nil {
+		t.Fatalf("GetGrantByUID() error = %v", err)
+	}
+	if got.QueryCount != 1 {
+		t.Errorf("QueryCount = %d, want 1 (only pre-revocation query counts)", got.QueryCount)
+	}
+	if got.BytesTransferred != 100 {
+		t.Errorf("BytesTransferred = %d, want 100 (only pre-revocation connection counts)", got.BytesTransferred)
+	}
+}
+
+func TestListGrants_PopulatesCountersForEach(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	user, db1 := createTestUserAndDatabase(t, ctx, store, "listcountersA")
+	_, db2 := createTestUserAndDatabase(t, ctx, store, "listcountersB")
+	admin, _ := store.CreateUser(ctx, "listcountersadmin", "hash", []string{RoleAdmin, RoleConnector})
+
+	now := time.Now()
+	g1, err := store.CreateGrant(ctx, &Grant{
+		UserID:     user.UID,
+		DatabaseID: db1.UID,
+		Controls:   []string{},
+		GrantedBy:  admin.UID,
+		StartsAt:   now.Add(-time.Hour),
+		ExpiresAt:  now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateGrant() error = %v", err)
+	}
+	g2, err := store.CreateGrant(ctx, &Grant{
+		UserID:     user.UID,
+		DatabaseID: db2.UID,
+		Controls:   []string{},
+		GrantedBy:  admin.UID,
+		StartsAt:   now.Add(-time.Hour),
+		ExpiresAt:  now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateGrant() error = %v", err)
+	}
+
+	// 1 query / 100 bytes on g1; 2 queries / 500 bytes on g2.
+	conn1, _ := store.CreateConnection(ctx, user.UID, db1.UID, "10.0.0.5")
+	if _, err := store.CreateQuery(ctx, &Query{ConnectionID: conn1.UID, SQLText: "x", ExecutedAt: now}); err != nil {
+		t.Fatalf("CreateQuery() error = %v", err)
+	}
+	if err := store.IncrementConnectionStats(ctx, conn1.UID, 100); err != nil {
+		t.Fatalf("IncrementConnectionStats() error = %v", err)
+	}
+
+	conn2, _ := store.CreateConnection(ctx, user.UID, db2.UID, "10.0.0.6")
+	for i := 0; i < 2; i++ {
+		if _, err := store.CreateQuery(ctx, &Query{ConnectionID: conn2.UID, SQLText: "y", ExecutedAt: now}); err != nil {
+			t.Fatalf("CreateQuery() error = %v", err)
+		}
+		if err := store.IncrementConnectionStats(ctx, conn2.UID, 250); err != nil {
+			t.Fatalf("IncrementConnectionStats() error = %v", err)
+		}
+	}
+
+	listed, err := store.ListGrants(ctx, GrantFilter{UserID: &user.UID})
+	if err != nil {
+		t.Fatalf("ListGrants() error = %v", err)
+	}
+
+	byUID := map[uuid.UUID]Grant{}
+	for _, g := range listed {
+		byUID[g.UID] = g
+	}
+	got1, ok1 := byUID[g1.UID]
+	got2, ok2 := byUID[g2.UID]
+	if !ok1 || !ok2 {
+		t.Fatalf("ListGrants() missing one of the grants: ok1=%v ok2=%v", ok1, ok2)
+	}
+	if got1.QueryCount != 1 || got1.BytesTransferred != 100 {
+		t.Errorf("g1 QueryCount=%d BytesTransferred=%d, want 1 / 100", got1.QueryCount, got1.BytesTransferred)
+	}
+	if got2.QueryCount != 2 || got2.BytesTransferred != 500 {
+		t.Errorf("g2 QueryCount=%d BytesTransferred=%d, want 2 / 500", got2.QueryCount, got2.BytesTransferred)
 	}
 }


### PR DESCRIPTION
## Summary
- **fix(grants)**: `GET /grants` and `GET /grants/{uid}` always returned `query_count: 0` / `bytes_transferred: 0`. Add a `populateGrantCounters` helper that aggregates `COUNT(*)` from `queries` and `SUM(bytes_transferred)` from `connections` within `[StartsAt, min(ExpiresAt, RevokedAt))`, called from `GetActiveGrant` (auth path), `GetGrantByUID`, and `ListGrants`. Side effect: the in-session bytes quota now enforces cumulative usage across sessions instead of resetting to 0 each connection. Removed two unused `Increment*` placeholder methods.
- **feat(ui)**: Dashboard "Recent Queries" rows now link to `/queries/:uid`, matching the full Queries page.
- **feat(ui)**: Users page replaces the per-row `…` dropdown with two inline icon buttons (Reset Password, Delete). Permission gating + tooltips preserved; e2e flow simplified accordingly.

## Test plan
- [x] `go test ./internal/store/...` — 234 passing, including 4 new tests covering populated counters, time-window exclusion, RevokedAt bound, and ListGrants per-row population
- [x] Live verification on `make dev`: `query_count` advanced 3 → 5 and `bytes_transferred` advanced 92 → 94 after running additional queries through the proxy
- [x] Frontend `tsc --noEmit` clean
- [ ] Manual UI check after merge: dashboard row click navigates, users page action buttons work for admin/non-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)