### PR TITLE
fix(config): default Slack notify channel to #dbbat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ make clean            # Clean build artifacts
 | `DBB_PG_TLS_CERT_FILE` | PEM cert for PostgreSQL TLS termination (auto self-signed if empty) | No |
 | `DBB_PG_TLS_KEY_FILE` | PEM key for PostgreSQL TLS termination (auto-generated if empty) | No |
 | `DBB_SLACK_NOTIFY_BOT_TOKEN` | Slack bot user OAuth token (`xoxb-...`); empty disables notifications | No |
-| `DBB_SLACK_NOTIFY_CHANNEL` | Slack channel id or name for grant-request notifications (e.g. `#dbbat`) | If notify enabled |
+| `DBB_SLACK_NOTIFY_CHANNEL` | Slack channel id or name for grant-request notifications (default: `#dbbat`) | No |
 | `DBB_PUBLIC_URL` | Externally reachable base URL; used for deep-links in Slack notifications | If notify enabled |
 
 Note: If no encryption key is provided, one is created at `~/.dbbat/key`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,7 +125,7 @@ type SlackNotifyConfig struct {
 	// disables notifications.
 	BotToken string `koanf:"bot_token"`
 	// Channel is the Slack channel id or name (e.g. "#dbbat") where
-	// notifications are posted.
+	// notifications are posted. Defaults to "#dbbat".
 	Channel string `koanf:"channel"`
 }
 
@@ -350,6 +350,9 @@ func defaultConfig() Config {
 		SlackAuth: SlackAuthConfig{
 			AutoCreateUsers: true,
 			DefaultRole:     "connector",
+		},
+		SlackNotify: SlackNotifyConfig{
+			Channel: "#dbbat",
 		},
 		Dump: DumpConfig{
 			MaxSize:   DefaultDumpMaxSize,


### PR DESCRIPTION
## Summary
Make `DBB_SLACK_NOTIFY_CHANNEL` optional once a bot token is set. The field was previously required even though `#dbbat` is the convention; this defaults it so deployers can enable Slack notifications by setting just `DBB_SLACK_NOTIFY_BOT_TOKEN`.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] Live test (separate, not on this branch): bot token + `#dbbat` channel verified end-to-end via `chat.postMessage`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)