### PR TITLE
fix(ui): fix favicon path and point preview at port 4200

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,8 +5,8 @@
       "name": "dbbat",
       "runtimeExecutable": "make",
       "runtimeArgs": ["dev"],
-      "port": 5173,
-      "url": "http://localhost:5173/app/"
+      "port": 4200,
+      "url": "http://localhost:4200/app/"
     }
   ]
 }

--- a/front/index.html
+++ b/front/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/app/favicon.png" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DBBat - PostgreSQL Observability Proxy</title>
   </head>

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig(() => {
     server: {
       proxy: {
         "/api": {
-          target: process.env.VITE_API_BASE_URL || "http://localhost:4200",
+          target: "http://localhost:8080",
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
## Summary

- **`front/index.html`**: favicon href was `/app/favicon.png` — with Vite base `/app/`, this got doubled to `/app/app/favicon.png`. Changed to `/favicon.png` so Vite's rewriting produces the correct `/app/favicon.png`.
- **`.claude/launch.json`**: switch preview URL to `http://localhost:4200/app/` — the backend serves all traffic (proxying to Vite in dev mode), so 4200 is the right entry point.
- **`front/vite.config.ts`**: revert proxy target back to `localhost:8080` (the original value — not used in the normal 4200 dev flow).

## Test plan

- [ ] Favicon appears correctly in browser tab (no doubled `/app/app/` path)
- [ ] Claude Code preview opens at `http://localhost:4200/app/` and shows login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)